### PR TITLE
Deploy to UI to GCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,38 @@
 language: node_js
 node_js:
   - node
-script:
-  - npm run lint
-  - npm run build
-  - npm test
+cache:
+  directories:
+    - $HOME/google-cloud-sdk/
+env:
+  global:
+    - PYTHONPATH=$PYTHONPATH:$(pwd)/cidc_api
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+    - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
+    - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
+    - GCLOUD_PROJECT_ID_PROD=cidc-dfci
+jobs:
+  include:
+    - stage: install
+      script: npm install
+    - stage: test
+      script: .travis/test.sh
+    - stage: build
+      script: .travis/build.sh
+    - stage: install gcloud
+      script: source .travis/install_gcloud.sh
+    - stage: deploy staging
+      script: .travis/deploy.sh gs://cidc-ui-staging
+    - stage: deploy prod
+      script: .travis/deploy.sh gs://cidc-ui-prod
+stages:
+  - install
+  - test
+  - name: build
+    if: branch = master OR branch = production
+  - name: install gcloud
+    if: branch = master OR branch = production
+  - name: deploy staging
+    if: branch = master
+  - name: deploy prod
+    if: branch = prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - $HOME/google-cloud-sdk/
 env:
   global:
-    - PYTHONPATH=$PYTHONPATH:$(pwd)/cidc_api
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1
     - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
     - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,15 @@ jobs:
     - stage: install
       script: npm install
     - stage: test
-      script: .travis/test.sh
+      script: sh .travis/test.sh
     - stage: build
-      script: .travis/build.sh
+      script: sh .travis/build.sh
     - stage: install gcloud
       script: source .travis/install_gcloud.sh
     - stage: deploy staging
-      script: .travis/deploy.sh gs://cidc-ui-staging
+      script: sh .travis/deploy.sh gs://cidc-ui-staging
     - stage: deploy prod
-      script: .travis/deploy.sh gs://cidc-ui-prod
+      script: sh .travis/deploy.sh gs://cidc-ui-prod
 stages:
   - install
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,28 +11,19 @@ env:
     - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
     - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
     - GCLOUD_PROJECT_ID_PROD=cidc-dfci
-jobs:
-  include:
-    - stage: install
-      script: npm install
-    - stage: test
-      script: sh .travis/test.sh
-    - stage: build
-      script: sh .travis/build.sh
-    - stage: install gcloud
-      script: source .travis/install_gcloud.sh
-    - stage: deploy staging
-      script: sh .travis/deploy.sh gs://cidc-ui-staging
-    - stage: deploy prod
-      script: sh .travis/deploy.sh gs://cidc-ui-prod
-stages:
-  - install
-  - test
-  - name: build
-    if: branch = master OR branch = production
-  - name: install gcloud
-    if: branch = master OR branch = production
-  - name: deploy staging
-    if: branch = master
-  - name: deploy prod
-    if: branch = prod
+install:
+  - npm install
+script:
+  - sh .travis/test.sh
+  - sh .travis/build.sh
+before_deploy:
+  - source .travis/install_gcloud.sh
+deploy:
+  - provider: script
+    script: sh .travis/deploy.sh gs://cidc-ui-staging
+    on:
+      branch: master
+  - provider: script
+    script: sh .travis/deploy.sh gs://cidc-ui-prod
+    on:
+      branch: production

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,8 @@
+# !/usr/bin/bash
+#
+# Create a production build of the CIDC Portal UI.
+
+# TODO: generate up-to-date shipping manifest templates 
+# and move these into public/static before running build
+
+npm build

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -5,4 +5,11 @@
 # TODO: generate up-to-date shipping manifest templates 
 # and move these into public/static before running build
 
+# Configure the environment based on the branch
+if [ "$TRAVIS_BRANCH" = production ]; then
+    cat .env.prod > .env
+else
+    cat .env.staging > .env
+fi
+
 npm build

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,11 @@
+# !/usr/bin/bash
+#
+# Deploy the UI to the current gcloud project.
+
+BUCKET=$1
+
+# Copy the contents of the build directory to the GCS UI bucket
+gsutil -m cp -r build/* $BUCKET
+
+# Make all objects in the GCS UI bucket public
+gsutil iam ch allUsers:objectViewer $BUCKET

--- a/.travis/install_gcloud.sh
+++ b/.travis/install_gcloud.sh
@@ -15,11 +15,9 @@ source $HOME/google-cloud-sdk/path.bash.inc
 if [ "$TRAVIS_BRANCH" = production ]; then
     gcloud config set project $GCLOUD_PROJECT_ID_PROD;
     export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
-    cat .env.prod > .env;
 else
     gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
     export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
-    cat .env.staging > .env;
 fi
 echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
 gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS

--- a/.travis/install_gcloud.sh
+++ b/.travis/install_gcloud.sh
@@ -1,0 +1,26 @@
+# !/usr/bin/bash
+#
+# Install the Google Cloud SDK. Values for these environment 
+# variables must be set in the Travis CI console for this to work:
+#   GCLOUD_SERVICE_ACCOUNT_JSON_STAGING
+#     -> base64-encoded service account JSON credentials for the staging project
+#   GCLOUD_SERVICE_ACCOUNT_JSON_PROD 
+#     -> base64-encoded service account JSON credentials for the production project
+
+if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+    rm -rf $HOME/google-cloud-sdk;
+    curl https://sdk.cloud.google.com | bash > /dev/null;
+fi
+source $HOME/google-cloud-sdk/path.bash.inc
+if [ "$TRAVIS_BRANCH" = production ]; then
+    gcloud config set project $GCLOUD_PROJECT_ID_PROD;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
+    cat .env.prod > .env;
+else
+    gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
+    cat .env.staging > .env;
+fi
+echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,6 @@
+# !/usr/bin/bash
+#
+# Test the CIDC Portal code.
+
+npm run lint
+npm test


### PR DESCRIPTION
Set up Travis to deploy the UI to GCS after a successful build on `master` or the not-yet-existent `production` branch.