### PR TITLE
Revert "Use Travis GCS provider for UI deployment"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,30 @@
 language: node_js
 node_js:
   - node
+cache:
+  directories:
+    - $HOME/google-cloud-sdk/
+env:
+  global:
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+    - GOOGLE_APPLICATION_CREDENTIALS=$HOME/credentials.json
+    - GCLOUD_PROJECT_ID_STAGING=cidc-dfci-staging
+    - GCLOUD_PROJECT_ID_PROD=cidc-dfci
 install:
   - npm install
 script:
   - sh .travis/test.sh
   - sh .travis/build.sh
+before_deploy:
+  - source .travis/install_gcloud.sh
 deploy:
-  - provider: gcs
-    bucket: cidc-ui-staging
-    access_key_id: $GCS_ACCESS_KEY_ID
-    secret_access_key: $GCS_SECRET_ACCESS_KEY
+  - provider: script
+    script: sh .travis/deploy.sh gs://cidc-ui-staging
     skip_cleanup: true
-    acl: public-read
     on:
       branch: master
-  - provider: gcs
-    bucket: cidc-ui-prod
-    access_key_id: $GCS_ACCESS_KEY_ID
-    secret_access_key: $GCS_SECRET_ACCESS_KEY
+  - provider: script
+    script: sh .travis/deploy.sh gs://cidc-ui-prod
     skip_cleanup: true
-    acl: public-read
     on:
       branch: production

--- a/.travis/install_gcloud.sh
+++ b/.travis/install_gcloud.sh
@@ -1,0 +1,24 @@
+# !/usr/bin/bash
+#
+# Install the Google Cloud SDK. Values for these environment 
+# variables must be set in the Travis CI console for this to work:
+#   GCLOUD_SERVICE_ACCOUNT_JSON_STAGING
+#     -> base64-encoded service account JSON credentials for the staging project
+#   GCLOUD_SERVICE_ACCOUNT_JSON_PROD 
+#     -> base64-encoded service account JSON credentials for the production project
+
+if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+    rm -rf $HOME/google-cloud-sdk;
+    curl https://sdk.cloud.google.com | bash > /dev/null;
+fi
+source $HOME/google-cloud-sdk/path.bash.inc
+if [ "$TRAVIS_BRANCH" = production ]; then
+    gcloud config set project $GCLOUD_PROJECT_ID_PROD;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_PROD";
+else
+    gcloud config set project $GCLOUD_PROJECT_ID_STAGING;
+    export GCLOUD_SERVICE_ACCOUNT_JSON="$GCLOUD_SERVICE_ACCOUNT_JSON_STAGING";
+fi
+echo "$GCLOUD_SERVICE_ACCOUNT_JSON" | base64 --decode > $GOOGLE_APPLICATION_CREDENTIALS
+gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+


### PR DESCRIPTION
Reverts CIMAC-CIDC/cidc-ui#75

The Travis GCS provider hangs without informative errors. This is a [known issue](https://github.com/travis-ci/dpl/issues/792), it seems, so let's move away from using it for now.