### PR TITLE
Remove old trial-level RBAC from the portal

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -37,7 +37,7 @@ function _getItem<T>(
         .then(_extractItem);
 }
 
-function _getItems<T>(token: string, endpoint: string): Promise<T> {
+function _getItems<T>(token: string, endpoint: string): Promise<T[]> {
     return getApiClient(token)
         .get(endpoint)
         .then(_extractItems);
@@ -123,16 +123,6 @@ async function deleteUser(
     return;
 }
 
-async function updateTrial(
-    token: string,
-    itemID: string,
-    etag: string,
-    collaborators: any
-): Promise<Trial | undefined> {
-    console.error("not currently supported");
-    return;
-}
-
 export {
     _getItem,
     _getItems,
@@ -144,7 +134,6 @@ export {
     getAllAccounts,
     updateRole,
     deleteUser,
-    updateTrial,
     getUserEtag,
     getManifestValidationErrors
 };

--- a/src/components/userAccount/AdminMenu.tsx
+++ b/src/components/userAccount/AdminMenu.tsx
@@ -116,6 +116,14 @@ export default class AdminMenu extends React.Component<any, {}> {
                                     }}
                                     onChange={this.handleSearchFilterChange}
                                 />
+                                <Typography color="error">
+                                    Warning! Trial access control is not
+                                    currently supported in the new API. All
+                                    users added to the system have access to all
+                                    trials. Until trial access control is
+                                    supported, only add members of the core CIDC
+                                    development team.
+                                </Typography>
                             </div>
                             <Table>
                                 <TableBody>

--- a/src/components/userAccount/UserAccountPage.tsx
+++ b/src/components/userAccount/UserAccountPage.tsx
@@ -45,19 +45,11 @@ export default class UserAccountPage extends React.Component<
 
     @autobind
     private getUserData() {
-        getAccountInfo(this.props.token).then(accountResults => {
-            getTrials(this.props.token).then(trialResults => {
-                const userTrials: Trial[] = [];
-                trialResults!.forEach(trial => {
-                    if (
-                        trial.collaborators.includes(accountResults![0].email)
-                    ) {
-                        userTrials.push(trial);
-                    }
-                });
-                this.setState({ trials: userTrials });
+        getAccountInfo(this.props.token).then(accountInfo => {
+            this.setState({ accountInfo });
+            getTrials(this.props.token).then(trials => {
+                this.setState({ trials });
             });
-            this.setState({ accountInfo: accountResults![0] });
         });
     }
 

--- a/src/components/userAccount/UserTableRow.tsx
+++ b/src/components/userAccount/UserTableRow.tsx
@@ -106,7 +106,7 @@ export default class UserTableRow extends React.Component<any, {}> {
                         size="small"
                         variant="outlined"
                         color="primary"
-                        disabled={!this.props.account.approved}
+                        disabled={!this.props.account.approval_date}
                         // tslint:disable-next-line:jsx-no-lambda
                         onClick={() => this.openTrials()}
                     >

--- a/src/components/userAccount/UserTrialsDialog.tsx
+++ b/src/components/userAccount/UserTrialsDialog.tsx
@@ -15,7 +15,7 @@ import {
     TablePagination
 } from "@material-ui/core";
 import autobind from "autobind-decorator";
-import { getTrials, updateTrial } from "../../api/api";
+import { getTrials } from "../../api/api";
 import { Trial } from "../../model/trial";
 
 export interface IUserTrialsDialogState {
@@ -48,19 +48,6 @@ export default class UserTrialsDialog extends React.Component<
         const newTrials: Trial[] = JSON.parse(
             JSON.stringify(this.state.trials)
         );
-        newTrials.forEach((trial: Trial) => {
-            if (trial._id === event.target.value) {
-                if (trial.collaborators.includes(this.props.account.email)) {
-                    trial.collaborators.splice(
-                        trial.collaborators.indexOf(this.props.account.email),
-                        1
-                    );
-                } else {
-                    trial.collaborators.push(this.props.account.email);
-                }
-            }
-        });
-
         this.setState({ trials: newTrials });
     }
 
@@ -71,20 +58,9 @@ export default class UserTrialsDialog extends React.Component<
 
     @autobind
     private handleSave() {
-        let updatedTrialCount: number = 0;
-        this.state.trials!.forEach((trial: Trial) => {
-            updateTrial(
-                this.props.token,
-                trial._id,
-                trial._etag,
-                trial.collaborators
-            ).then(results => {
-                updatedTrialCount++;
-                if (this.state.trials!.length === updatedTrialCount) {
-                    this.props.onCancel();
-                }
-            });
-        });
+        window.alert(
+            "Trial access controls are not yet supported in the new API."
+        );
     }
 
     @autobind
@@ -103,14 +79,9 @@ export default class UserTrialsDialog extends React.Component<
     }
 
     public render() {
-        const selectedTrialIds: string[] = [];
-        if (this.state.trials) {
-            this.state.trials.forEach(trial => {
-                if (trial.collaborators.includes(this.props.account.email)) {
-                    selectedTrialIds.push(trial.trial_id);
-                }
-            });
-        }
+        const selectedTrialIds: string[] = this.state.trials
+            ? this.state.trials.map(t => t.trial_id)
+            : [];
 
         return (
             <>

--- a/src/model/trial.ts
+++ b/src/model/trial.ts
@@ -3,8 +3,6 @@ export interface Trial {
     _id: string;
     _etag: string;
     trial_id: string;
-    // NOTE: these fields are not supported by the new API.
     // TODO: implement role-based access to Trial resources in the new API.
-    collaborators: string[];
-    locked: boolean;
+    // TODO: add missing fields (e.g., assays, participants) to this object.
 }


### PR DESCRIPTION
The trial objects getting sent from the new API don't have a `collaborators` field, and we plan on deprecating this permissions system soon. This PR removes the unused `collaborators` concept from the portal.