### PR TITLE
Fix getAccountInfo query

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -20,7 +20,7 @@ const ENDPOINT = "some/route";
 
 beforeEach(() => axiosMock.reset());
 
-function respondsWith404(p: AxiosPromise) {
+function respondsWith404(p: Promise<any>) {
     return p.catch(({ response }) => {
         expect(response.status).toBe(404);
     });
@@ -63,8 +63,8 @@ test("getAccountInfo", done => {
     const payload = { _items: [OBJECT] };
 
     axiosMock.onGet("users").reply(config => {
-        expect(config.params.email).toBeDefined();
-        expect(config.params.email).toBe(EMAIL);
+        expect(config.params.where).toBeDefined();
+        expect(config.params.where).toEqual({ email: EMAIL });
         return [200, payload];
     });
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -59,7 +59,7 @@ function getAccountInfo(token: string): Promise<Account | undefined> {
     const email = decodedToken!.email;
 
     return getApiClient(token)
-        .get("users", { params: { email } })
+        .get("users", { params: { where: { email } } })
         .then(res => {
             const users = _extractItems(res);
             return users ? users[0] : undefined;

--- a/src/components/userAccount/UserAccountPage.tsx
+++ b/src/components/userAccount/UserAccountPage.tsx
@@ -58,6 +58,8 @@ export default class UserAccountPage extends React.Component<
             return null;
         }
 
+        console.log(this.state.accountInfo);
+
         return (
             <div>
                 <Paper className="User-account-paper">


### PR DESCRIPTION
The query parameter for filtering by user email was incorrectly formed - we need integration tests to catch things like this.