### PR TITLE
Update lingering file_type references

### DIFF
--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -114,7 +114,7 @@ export default class BrowseFilesPage extends React.Component<
                                     _.map(this.state.files, "assay_type")
                                 )}
                                 dataFormats={_.uniq(
-                                    _.map(this.state.files, "file_type")
+                                    _.map(this.state.files, "data_format")
                                 )}
                                 onTrialIdChange={this.handleTrialIdChange}
                                 onExperimentalStrategyChange={

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -19,7 +19,7 @@ import { Trial } from "../../model/trial";
 const NAME_KEY = "object_url";
 const TRIAL_ID_KEY = "trial_id";
 const ASSAY_TYPE_KEY = "assay_type";
-const FILE_TYPE_KEY = "file_type";
+const FILE_TYPE_KEY = "data_format";
 const SIZE_KEY = "file_size_bytes";
 
 export interface IFileTableProps {


### PR DESCRIPTION
The `DataFile` property is now called `data_format`.