### PR TITLE
PBMC ingestion

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,4 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=https://staging-api.cimac-network.org
+REACT_APP_API_URL=http://localhost:5000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1352,6 +1352,12 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -1516,6 +1522,99 @@
         "@svgr/plugin-jsx": "^4.1.0",
         "@svgr/plugin-svgo": "^4.0.3",
         "loader-utils": "^1.1.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.2.0.tgz",
+      "integrity": "sha512-YaaoAIDTNV8AfC19XLa6KNeBB5KuSxWYPrgYN1vBu1i+czQlfWJSCS0A3yd2V3BUH9di9C1BD+7OoyVBpZCh2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.0.0",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+          "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.1.0.tgz",
+      "integrity": "sha512-cKAONDmJKGJ2DSu6R/+lgA8i8uyZIx4CaOiiK0yMjp+2UecH6kfjunJiy5hfExKMtR74eyzFriqO1w9aTC8VyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.1",
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+          "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.1.4.tgz",
+      "integrity": "sha512-fQ/PXZoLcmnS1W5ZiM3P7XBy2x6Hm9cJAT/ZDuZKzJ1fS1rN3j31p7ReAqUe3N1kJ46sNot0n1oiGbz7FPU+FA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^6.1.0",
+        "@types/testing-library__react": "^9.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+          "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
       }
     },
     "@types/auth0-js": {
@@ -1785,6 +1884,25 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/testing-library__dom": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.0.3.tgz",
+      "integrity": "sha512-NCjixGZ6iubYpe63YKYJy/bDkPp+HD8fbi+0iXcaYhsYjQhoa7IfFz/WcaCRZJnKSi63c9GSK9pZi/Y8/gTvFA==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.3.0"
+      }
+    },
+    "@types/testing-library__react": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.1.tgz",
+      "integrity": "sha512-8/toTJaIlS3BC7JrK2ElTnbjH8tmFP7atdL2ZsIa1JDmH9RKSm/7Wp5oMDJzXoWr988Mv7ym/XZ8LRglyoGCGw==",
+      "dev": true,
+      "requires": {
+        "@types/react-dom": "*",
+        "@types/testing-library__dom": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "2.3.5",
@@ -4368,6 +4486,26 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
       "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -4491,6 +4629,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "4.4.0",
@@ -9499,6 +9643,12 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
@@ -11975,6 +12125,24 @@
         "minimatch": "3.0.4"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -13195,6 +13363,15 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -14056,6 +14233,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "lint": "tslint -p tsconfig.json"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^4.1.0",
+    "@testing-library/react": "^9.1.4",
     "@types/jest": "^23.3.9",
     "@types/node": "^10.12.2",
     "@types/react": "^16.7.18",

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -3,6 +3,8 @@ import MockAdapter from "axios-mock-adapter";
 import {
     _getItem,
     _getItems,
+    _extractErrorMessage,
+    getApiClient,
     getAccountInfo,
     getManifestValidationErrors,
     updateRole
@@ -56,6 +58,47 @@ describe("_getItems", () => {
 
     it("bubbles up a 404 on non-existent items", done => {
         respondsWith404(_getItems(TOKEN, ENDPOINT)).then(done);
+    });
+});
+
+describe("_extractErrorMessage", () => {
+    const endpoint = "foo";
+    const client = getApiClient(TOKEN);
+
+    it("handles non-Eve-style error messages", done => {
+        const message = "an error message";
+        axiosMock.onGet(endpoint).reply(() => [401, message]);
+        client
+            .get(endpoint)
+            .catch(_extractErrorMessage)
+            .catch(err => expect(err).toBe(message))
+            .then(done);
+    });
+
+    it("handles Eve-style error messages", done => {
+        const eveError = {
+            _status: "ERR",
+            _error: { message: "blah" }
+        };
+        axiosMock.onGet(endpoint).reply(() => [401, eveError]);
+        client
+            .get(endpoint)
+            .catch(_extractErrorMessage)
+            .catch(err => expect(err).toBe(eveError._error.message))
+            .then(done);
+    });
+
+    it("handles empty error messages", done => {
+        axiosMock.onGet(endpoint).reply(() => [401, undefined]);
+        client
+            .get(endpoint)
+            .catch(_extractErrorMessage)
+            .catch(err => {
+                console.log(err);
+                throw err;
+            })
+            .catch(err => expect(err.includes("401")).toBeTruthy())
+            .then(done);
     });
 });
 

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -93,10 +93,6 @@ describe("_extractErrorMessage", () => {
         client
             .get(endpoint)
             .catch(_extractErrorMessage)
-            .catch(err => {
-                console.log(err);
-                throw err;
-            })
             .catch(err => expect(err.includes("401")).toBeTruthy())
             .then(done);
     });

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -126,9 +126,18 @@ function _makeManifestRequest<T>(
         .catch(_extractErrorMessage);
 }
 
-// TODO: determine the appropriate return type for this function based on API implementation.
-function uploadManifest(token: string, form: IManifestForm): Promise<any> {
-    return _makeManifestRequest("ingestion/upload_manifest", token, form);
+interface IManifestUploadResponse {
+    metadata_json_patch: { lead_organization_study_id: string };
+}
+function uploadManifest(
+    token: string,
+    form: IManifestForm
+): Promise<IManifestUploadResponse> {
+    return _makeManifestRequest<IManifestUploadResponse>(
+        "ingestion/upload_manifest",
+        token,
+        form
+    ).then(_extractItem);
 }
 
 function getManifestValidationErrors(

--- a/src/components/templates/TemplateUpload.test.tsx
+++ b/src/components/templates/TemplateUpload.test.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import {
+    render,
+    fireEvent,
+    waitForElement,
+    RenderResult
+} from "@testing-library/react";
+import TemplateUpload from "./TemplateUpload";
+import { XLSX_MIMETYPE } from "../../util/constants";
+import Auth, { AuthContext } from "../../auth/Auth";
+import { getManifestValidationErrors } from "../../api/api";
+jest.mock("../../api/api");
+
+const TOKEN = "BLAH";
+
+function renderWithMockedAuthContext() {
+    const mockAuth = new Auth(jest.fn(), jest.fn());
+
+    mockAuth.getIdToken = jest.fn(() => TOKEN);
+
+    return render(
+        <AuthContext.Provider value={mockAuth}>
+            <TemplateUpload cardClass="foo" />
+        </AuthContext.Provider>
+    );
+}
+
+/**
+ * Fire a selection event on a material UI Select component.
+ * @param select the HTML select element under test
+ * @param value the value to simulate selecting
+ */
+async function selectValueMUI(
+    renderResult: RenderResult,
+    select: Element,
+    value: string
+) {
+    const { getAllByRole, getByText } = renderResult;
+    const selectButton = getAllByRole("button", { container: select })[0];
+    fireEvent.click(selectButton);
+    const valueButton = await waitForElement(() => getByText(value));
+    fireEvent.click(valueButton);
+}
+
+test("manifest validation", async () => {
+    const renderResult = renderWithMockedAuthContext();
+    const { queryByTestId, getByTestId, getByText } = renderResult;
+    const manifestTypeSelect = getByTestId("manifest-type-select");
+    const manifestFileInput = getByTestId("manifest-file-input");
+    const submitButton = getByTestId("submit-button");
+
+    function expectNoValidationsDisplayed() {
+        expect(queryByTestId("no-selection")).toBeInTheDocument();
+        expect(queryByTestId("valid-manifest")).toBeNull();
+        expect(queryByTestId("errors")).toBeNull();
+    }
+
+    // Defaults on first render to no validations, disabled submit
+    expectNoValidationsDisplayed();
+    expect(submitButton).toHaveAttribute("disabled");
+
+    // Select a manifest type. Material UI components make this
+    // difficult: we need to first click on the select component,
+    // then click on the dropdown option that subsequently appears.
+    selectValueMUI(renderResult, manifestTypeSelect, "PBMC");
+    expectNoValidationsDisplayed();
+    expect(submitButton).toHaveAttribute("disabled");
+
+    async function doValidationRequest(errors: string[], element: string) {
+        getManifestValidationErrors.mockResolvedValue(errors);
+
+        fireEvent.click(manifestFileInput);
+
+        const fakePBMCFile = new File(["foo"], "pbmc.xlsx", {
+            type: XLSX_MIMETYPE
+        });
+        fireEvent.change(manifestFileInput, {
+            target: { files: [fakePBMCFile] }
+        });
+
+        expect(submitButton).toHaveAttribute("disabled");
+
+        await waitForElement(() => queryByTestId(element)!);
+    }
+
+    // Check that validation errors show up and submit button is still disabled
+    const errs = ["a", "b", "c"];
+    await doValidationRequest(errs, "errors");
+    errs.map(e => expect(getByText(e)).toBeInTheDocument());
+    expect(submitButton).toHaveAttribute("disabled");
+
+    // Check that valid message shows up and submit button is enabled
+    await doValidationRequest([], "valid-manifest");
+    expect(queryByTestId("valid-manifest")).toBeInTheDocument();
+    expect(submitButton).not.toHaveAttribute("disabled");
+});

--- a/src/components/templates/TemplateUpload.test.tsx
+++ b/src/components/templates/TemplateUpload.test.tsx
@@ -50,9 +50,9 @@ test("manifest validation", async () => {
     const submitButton = getByTestId("submit-button");
 
     function expectNoValidationsDisplayed() {
-        expect(queryByTestId("no-selection")).toBeInTheDocument();
-        expect(queryByTestId("valid-manifest")).not.toBeInTheDocument();
-        expect(queryByTestId("errors")).not.toBeInTheDocument();
+        expect(queryByTestId("unset")).toBeInTheDocument();
+        expect(queryByTestId("validationSuccess")).not.toBeInTheDocument();
+        expect(queryByTestId("validationErrors")).not.toBeInTheDocument();
     }
 
     // Defaults on first render to no validations, disabled submit
@@ -81,20 +81,20 @@ test("manifest validation", async () => {
         expect(submitButton).toHaveAttribute("disabled");
 
         await waitForElement(() => queryByTestId(element)!);
-        expect(queryByTestId("no-selection")).not.toBeInTheDocument();
+        expect(queryByTestId("unset")).not.toBeInTheDocument();
     }
 
     // Check that validation errors show up and submit button is still disabled
     const errs = ["a", "b", "c"];
-    await doValidationRequest(errs, "errors");
+    await doValidationRequest(errs, "validationErrors");
     errs.map(e => expect(getByText(e)).toBeInTheDocument());
-    expect(queryByTestId("valid-manifest")).not.toBeInTheDocument();
+    expect(queryByTestId("validationSuccess")).not.toBeInTheDocument();
     expect(submitButton).toHaveAttribute("disabled");
 
     // Check that valid message shows up and submit button is enabled
-    await doValidationRequest([], "valid-manifest");
-    expect(queryByTestId("valid-manifest")).toBeInTheDocument();
-    expect(queryByTestId("errors")).not.toBeInTheDocument();
+    await doValidationRequest([], "validationSuccess");
+    expect(queryByTestId("validationSuccess")).toBeInTheDocument();
+    expect(queryByTestId("validationErrors")).not.toBeInTheDocument();
     expect(submitButton).not.toHaveAttribute("disabled");
 });
 
@@ -117,14 +117,14 @@ test("manifest submission", async () => {
     fireEvent.change(manifestFileInput, {
         target: { files: [fakePBMCFile] }
     });
-    await waitForElement(() => getByTestId("valid-manifest")!);
+    await waitForElement(() => getByTestId("validationSuccess")!);
 
     // Submit the manifest
     uploadManifest.mockResolvedValue({
         metadata_json_patch: { lead_organization_study_id: "CIMAC-12345" }
     });
     fireEvent.click(submitButton);
-    expect(queryByTestId("upload-success")).not.toBeInTheDocument();
-    const result = await waitForElement(() => getByTestId("upload-success"));
+    expect(queryByTestId("uploadSuccess")).not.toBeInTheDocument();
+    const result = await waitForElement(() => getByTestId("uploadSuccess"));
     expect(result).toBeInTheDocument();
 });

--- a/src/components/templates/TemplateUpload.test.tsx
+++ b/src/components/templates/TemplateUpload.test.tsx
@@ -8,7 +8,7 @@ import {
 import TemplateUpload from "./TemplateUpload";
 import { XLSX_MIMETYPE } from "../../util/constants";
 import Auth, { AuthContext } from "../../auth/Auth";
-import { getManifestValidationErrors } from "../../api/api";
+import { getManifestValidationErrors, uploadManifest } from "../../api/api";
 jest.mock("../../api/api");
 
 const TOKEN = "BLAH";
@@ -62,7 +62,7 @@ test("manifest validation", async () => {
     // Select a manifest type. Material UI components make this
     // difficult: we need to first click on the select component,
     // then click on the dropdown option that subsequently appears.
-    selectValueMUI(renderResult, manifestTypeSelect, "PBMC");
+    await selectValueMUI(renderResult, manifestTypeSelect, "PBMC");
     expectNoValidationsDisplayed();
     expect(submitButton).toHaveAttribute("disabled");
 
@@ -81,16 +81,47 @@ test("manifest validation", async () => {
         expect(submitButton).toHaveAttribute("disabled");
 
         await waitForElement(() => queryByTestId(element)!);
+        expect(queryByTestId("no-selection")).toBeNull();
     }
 
     // Check that validation errors show up and submit button is still disabled
     const errs = ["a", "b", "c"];
     await doValidationRequest(errs, "errors");
     errs.map(e => expect(getByText(e)).toBeInTheDocument());
+    expect(queryByTestId("valid-manifest")).toBeNull();
     expect(submitButton).toHaveAttribute("disabled");
 
     // Check that valid message shows up and submit button is enabled
     await doValidationRequest([], "valid-manifest");
     expect(queryByTestId("valid-manifest")).toBeInTheDocument();
+    expect(queryByTestId("errors")).toBeNull();
     expect(submitButton).not.toHaveAttribute("disabled");
+});
+
+test("manifest submission", async () => {
+    const renderResult = renderWithMockedAuthContext();
+    const { getByTestId, getByText } = renderResult;
+    const manifestTypeSelect = getByTestId("manifest-type-select");
+    const manifestFileInput = getByTestId("manifest-file-input");
+    const submitButton = getByTestId("submit-button");
+
+    // Select a manifest type
+    selectValueMUI(renderResult, manifestTypeSelect, "PBMC");
+
+    // Select a file to upload and wait for validations to complete
+    getManifestValidationErrors.mockResolvedValue([]);
+    fireEvent.click(manifestFileInput);
+    const fakePBMCFile = new File(["foo"], "pbmc.xlsx", {
+        type: XLSX_MIMETYPE
+    });
+    fireEvent.change(manifestFileInput, {
+        target: { files: [fakePBMCFile] }
+    });
+    await waitForElement(() => getByTestId("valid-manifest")!);
+
+    // Submit the manifest
+    uploadManifest.mockResolvedValue({
+        metadata_json_patch: { lead_organization_study_id: "CIMAC-12345" }
+    });
+    fireEvent.click(submitButton);
 });

--- a/src/components/templates/TemplateUpload.test.tsx
+++ b/src/components/templates/TemplateUpload.test.tsx
@@ -51,8 +51,8 @@ test("manifest validation", async () => {
 
     function expectNoValidationsDisplayed() {
         expect(queryByTestId("no-selection")).toBeInTheDocument();
-        expect(queryByTestId("valid-manifest")).toBeNull();
-        expect(queryByTestId("errors")).toBeNull();
+        expect(queryByTestId("valid-manifest")).not.toBeInTheDocument();
+        expect(queryByTestId("errors")).not.toBeInTheDocument();
     }
 
     // Defaults on first render to no validations, disabled submit
@@ -81,26 +81,26 @@ test("manifest validation", async () => {
         expect(submitButton).toHaveAttribute("disabled");
 
         await waitForElement(() => queryByTestId(element)!);
-        expect(queryByTestId("no-selection")).toBeNull();
+        expect(queryByTestId("no-selection")).not.toBeInTheDocument();
     }
 
     // Check that validation errors show up and submit button is still disabled
     const errs = ["a", "b", "c"];
     await doValidationRequest(errs, "errors");
     errs.map(e => expect(getByText(e)).toBeInTheDocument());
-    expect(queryByTestId("valid-manifest")).toBeNull();
+    expect(queryByTestId("valid-manifest")).not.toBeInTheDocument();
     expect(submitButton).toHaveAttribute("disabled");
 
     // Check that valid message shows up and submit button is enabled
     await doValidationRequest([], "valid-manifest");
     expect(queryByTestId("valid-manifest")).toBeInTheDocument();
-    expect(queryByTestId("errors")).toBeNull();
+    expect(queryByTestId("errors")).not.toBeInTheDocument();
     expect(submitButton).not.toHaveAttribute("disabled");
 });
 
 test("manifest submission", async () => {
     const renderResult = renderWithMockedAuthContext();
-    const { getByTestId, getByText } = renderResult;
+    const { getByTestId, queryByTestId } = renderResult;
     const manifestTypeSelect = getByTestId("manifest-type-select");
     const manifestFileInput = getByTestId("manifest-file-input");
     const submitButton = getByTestId("submit-button");
@@ -124,4 +124,7 @@ test("manifest submission", async () => {
         metadata_json_patch: { lead_organization_study_id: "CIMAC-12345" }
     });
     fireEvent.click(submitButton);
+    expect(queryByTestId("upload-success")).not.toBeInTheDocument();
+    const result = await waitForElement(() => getByTestId("upload-success"));
+    expect(result).toBeInTheDocument();
 });

--- a/src/components/templates/TemplateUpload.tsx
+++ b/src/components/templates/TemplateUpload.tsx
@@ -45,6 +45,9 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
     const [status, setStatus] = React.useState<Status>("unset");
     const [errors, setErrors] = React.useState<string[] | undefined>(undefined);
     const [file, setFile] = React.useState<File | undefined>(undefined);
+    const [targetTrial, setTargetTrial] = React.useState<string | undefined>(
+        undefined
+    );
 
     // When the manifest file or manifest type changes, run validations
     React.useEffect(() => {
@@ -75,8 +78,11 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                 schema: manifestType,
                 template: file
             })
-                .then(() => {
+                .then(({ metadata_json_patch }) => {
                     setStatus("uploadSuccess");
+                    setTargetTrial(
+                        metadata_json_patch.lead_organization_study_id
+                    );
                 })
                 .catch(err => {
                     setErrors([`Upload failed: ${err.toString()}`]);
@@ -124,7 +130,7 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
         uploadSuccess: (
             <List dense data-testid="uploadSuccess">
                 {successMessage(
-                    "Successfully uploaded {manifestType} manifest."
+                    `Successfully uploaded ${manifestType} manifest to ${targetTrial}.`
                 )}
             </List>
         )

--- a/src/components/templates/TemplateUpload.tsx
+++ b/src/components/templates/TemplateUpload.tsx
@@ -85,47 +85,47 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
         }
     };
 
+    const errorList =
+        errors &&
+        errors.map(error => (
+            <ListItem key={error}>
+                <ListItemIcon>
+                    <WarningRounded color="error" />
+                </ListItemIcon>
+                <ListItemText>{error}</ListItemText>
+            </ListItem>
+        ));
+
+    const successMessage = (message: string) => (
+        <ListItem>
+            <ListItemIcon>
+                <CheckBoxRounded color="primary" />
+            </ListItemIcon>
+            <ListItemText>{message}</ListItemText>
+        </ListItem>
+    );
+
     const feedbackDisplay: { [k in Status]: React.ReactElement } = {
         unset: (
-            <Typography color="textSecondary" data-testid="no-selection">
+            <Typography color="textSecondary" data-testid="unset">
                 Select a manifest to view validations.
             </Typography>
         ),
         loading: <Loader size={32} />,
         validationErrors: (
-            <List data-testid="errors">
-                {errors &&
-                    errors.map(error => (
-                        <ListItem key={error}>
-                            <ListItemIcon>
-                                <WarningRounded color="error" />
-                            </ListItemIcon>
-                            <ListItemText>{error}</ListItemText>
-                        </ListItem>
-                    ))}
-            </List>
+            <List data-testid="validationErrors">{errorList}</List>
         ),
         validationSuccess: (
-            <List dense data-testid="valid-manifest">
-                <ListItem>
-                    <ListItemIcon>
-                        <CheckBoxRounded color="primary" />
-                    </ListItemIcon>
-                    <ListItemText>Manifest is valid.</ListItemText>
-                </ListItem>
+            <List dense data-testid="validationSuccess">
+                {successMessage("Manifest is valid.")}
             </List>
         ),
-        uploadErrors: "oopsies",
+        uploadErrors: <List data-testid="uploadErrors">{errorList}</List>,
         uploadSuccess: (
-            <List dense data-testid="upload-success">
-                <ListItem>
-                    <ListItemIcon>
-                        <CheckBoxRounded color="primary" />
-                    </ListItemIcon>
-                    <ListItemText>
-                        Successfully uploaded {manifestType} manifest.
-                    </ListItemText>
-                </ListItem>
+            <List dense data-testid="uploadSuccess">
+                {successMessage(
+                    "Successfully uploaded {manifestType} manifest."
+                )}
             </List>
         )
     };

--- a/src/components/templates/TemplateUpload.tsx
+++ b/src/components/templates/TemplateUpload.tsx
@@ -8,13 +8,13 @@ import {
     Grid,
     Input,
     InputLabel,
-    MenuItem,
     Select,
     List,
     ListItem,
     ListItemText,
-    ListItemAvatar,
-    Divider
+    Divider,
+    MenuItem,
+    ListItemIcon
 } from "@material-ui/core";
 import { ITemplateCardProps } from "./TemplatesPage";
 import { allNames, onValueChange } from "./utils";
@@ -93,7 +93,8 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                                 <Select
                                     inputProps={{
                                         id: "manifestType",
-                                        name: "type"
+                                        name: "type",
+                                        "data-testid": "manifest-type-select"
                                     }}
                                     value={manifestType || ""}
                                     onChange={onValueChange(setManifestType)}
@@ -135,7 +136,8 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                                     }}
                                     inputProps={{
                                         ref: fileInput,
-                                        accept: XLSX_MIMETYPE
+                                        accept: XLSX_MIMETYPE,
+                                        "data-testid": "manifest-file-input"
                                     }}
                                     type="file"
                                 />
@@ -148,6 +150,7 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                                 variant="contained"
                                 color="primary"
                                 disabled={!fileValid}
+                                data-testid="submit-button"
                             >
                                 Upload
                             </Button>
@@ -166,30 +169,33 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                         {isValidating || isSubmitting ? (
                             <Loader size={32} />
                         ) : errors === undefined ? (
-                            <Typography color="textSecondary">
+                            <Typography
+                                color="textSecondary"
+                                data-testid="no-selection"
+                            >
                                 Select a manifest to view validations.
                             </Typography>
+                        ) : errors.length === 0 ? (
+                            <List dense data-testid="valid-manifest">
+                                <ListItem>
+                                    <ListItemIcon>
+                                        <CheckBoxRounded color="primary" />
+                                    </ListItemIcon>
+                                    <ListItemText>
+                                        Manifest is valid.
+                                    </ListItemText>
+                                </ListItem>
+                            </List>
                         ) : (
-                            <List dense>
-                                {errors.length === 0 ? (
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <CheckBoxRounded color="primary" />
-                                        </ListItemAvatar>
-                                        <ListItemText>
-                                            Manifest is valid.
-                                        </ListItemText>
+                            <List data-testid="errors">
+                                {errors.map(error => (
+                                    <ListItem key={error}>
+                                        <ListItemIcon>
+                                            <WarningRounded color="error" />
+                                        </ListItemIcon>
+                                        <ListItemText>{error}</ListItemText>
                                     </ListItem>
-                                ) : (
-                                    errors.map(error => (
-                                        <ListItem key={error}>
-                                            <ListItemAvatar>
-                                                <WarningRounded color="error" />
-                                            </ListItemAvatar>
-                                            <ListItemText>{error}</ListItemText>
-                                        </ListItem>
-                                    ))
-                                )}
+                                ))}
                             </List>
                         )}
                     </Grid>

--- a/src/components/templates/TemplateUpload.tsx
+++ b/src/components/templates/TemplateUpload.tsx
@@ -18,7 +18,7 @@ import {
 } from "@material-ui/core";
 import { ITemplateCardProps } from "./TemplatesPage";
 import { allNames, onValueChange } from "./utils";
-import { getManifestValidationErrors } from "../../api/api";
+import { getManifestValidationErrors, uploadManifest } from "../../api/api";
 import { AuthContext } from "../../auth/Auth";
 import { WarningRounded, CheckBoxRounded } from "@material-ui/icons";
 import { XLSX_MIMETYPE } from "../../util/constants";
@@ -35,6 +35,7 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
         undefined
     );
     const [isValidating, setIsValidating] = React.useState<boolean>(false);
+    const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);
     const [errors, setErrors] = React.useState<string[] | undefined>(undefined);
     const [file, setFile] = React.useState<File | undefined>(undefined);
 
@@ -57,8 +58,18 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
 
     const onSubmit = (e: React.SyntheticEvent) => {
         e.preventDefault();
-        // TODO: enable manifest uploads once the API supports it
-        window.alert("Manifest uploads are not yet supported.");
+        if (manifestType && file) {
+            setIsSubmitting(true);
+            uploadManifest(auth.getIdToken()!, {
+                schema: manifestType,
+                template: file
+            })
+                .then(() => setIsSubmitting(false))
+                .catch(err => {
+                    setErrors([`Upload failed: ${err.toString()}`]);
+                    setIsSubmitting(false);
+                });
+        }
     };
 
     return (
@@ -152,7 +163,7 @@ const TemplateUpload: React.FunctionComponent<ITemplateCardProps> = (
                     }}
                 >
                     <Grid container direction="row" alignItems="center">
-                        {isValidating ? (
+                        {isValidating || isSubmitting ? (
                             <Loader size={32} />
                         ) : errors === undefined ? (
                             <Typography color="textSecondary">

--- a/src/components/templates/utils.ts
+++ b/src/components/templates/utils.ts
@@ -6,7 +6,6 @@ export const allNames = {
 };
 
 export function onValueChange(setState: (v: string | undefined) => void) {
-    return (e: React.ChangeEvent<HTMLSelectElement>) => {
+    return (e: React.ChangeEvent<HTMLSelectElement>) =>
         setState(e.target.value);
-    };
 }

--- a/src/components/templates/utils.ts
+++ b/src/components/templates/utils.ts
@@ -6,6 +6,7 @@ export const allNames = {
 };
 
 export function onValueChange(setState: (v: string | undefined) => void) {
-    return (e: React.ChangeEvent<HTMLSelectElement>) =>
+    return (e: React.ChangeEvent<HTMLSelectElement>) => {
         setState(e.target.value);
+    };
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,8 @@ const localStorageMock = {
     getItem: jest.fn(),
     setItem: jest.fn(),
     removeItem: jest.fn(),
-    clear: jest.fn(),
+    clear: jest.fn()
 };
 (global as any).localStorage = localStorageMock;
+
+import "@testing-library/jest-dom/extend-expect";

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "no-console": false,
     "trailing-comma": false,
     "arrow-parens": false,
-    "quotemark": false
+    "quotemark": false,
+    "object-literal-key-quotes": [true, "as-needed"]
   }
 }


### PR DESCRIPTION
Changes to allow manifest uploads accompanying https://github.com/CIMAC-CIDC/cidc-api-gae/pull/78

Now, clicking the "Upload" button actually triggers an upload. A successful upload produces a basic success message, and a failed upload just pastes the request error message to the "feedback" section in the manifest uploads card.

Also, adds a test for UI logic for the entire `TemplateUpload` component. As we add features throughout the UI, we'll want to add more tests like these (currently, there are nearly none).