### PR TITLE
Wrap file names in file table to avoid overflow

### DIFF
--- a/src/components/browseFiles/BrowseFiles.css
+++ b/src/components/browseFiles/BrowseFiles.css
@@ -33,6 +33,7 @@
 
 .File-table {
     border: 1px solid #cfd0d0;
+    border-radius: 5px;
 }
 
 .File-table-row {
@@ -43,6 +44,10 @@
     font-size: 14px !important;
 }
 
+.filename {
+    word-break: break-word;
+}
+
 .File-table-header-cell {
     font-size: 13px !important;
 }
@@ -50,6 +55,7 @@
 .File-search {
     background-color: white;
     margin-top: 0 !important;
+    border-radius: 5px;
 }
 
 .File-search-input {
@@ -62,7 +68,7 @@
 }
 
 .File-search-border fieldset {
-    border-radius: 0;
+    border-radius: 5px;
 }
 
 .Browse-files-progress {

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -167,7 +167,7 @@ export default class FileTable extends React.Component<
                                             this.handleClick(file.id)
                                         }
                                     >
-                                        <TableCell className="File-table-row-cell">
+                                        <TableCell className="File-table-row-cell filename">
                                             {file.object_url}
                                         </TableCell>
                                         <TableCell className="File-table-row-cell">


### PR DESCRIPTION
before:
<img width="1380" alt="Screen Shot 2019-10-02 at 2 16 02 PM" src="https://user-images.githubusercontent.com/14116434/66070545-82a35580-e51f-11e9-83f1-1dfeca707aa4.png">
after:
<img width="1380" alt="Screen Shot 2019-10-02 at 2 16 19 PM" src="https://user-images.githubusercontent.com/14116434/66070554-86cf7300-e51f-11e9-8983-b8e852d4f9dc.png">

