### PR TITLE
Display additional metadata on the file details page

### DIFF
--- a/src/components/browseFiles/AdditionalMetadataTable.tsx
+++ b/src/components/browseFiles/AdditionalMetadataTable.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import map from "lodash/map";
+import {
+    Table,
+    TableHead,
+    TableRow,
+    TableCell,
+    TableBody
+} from "@material-ui/core";
+
+export interface IFileDetailsTableProps {
+    metadata: { [prop: string]: any };
+}
+
+const AdditionalMetadataTable: React.FunctionComponent<
+    IFileDetailsTableProps
+> = props => {
+    const processKey = (key: string) => key.replace("assays.", "");
+    const processValue = (value: any) => {
+        if (value instanceof Array) {
+            return value.join(", ");
+        }
+        return value.toString();
+    };
+    return (
+        <div className="File-table">
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell className="File-table-header-cell">
+                            Attribute Name
+                        </TableCell>
+                        <TableCell className="File-table-header-cell">
+                            Value
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {map(props.metadata, (value, key) => (
+                        <TableRow key={key}>
+                            <TableCell className="File-table-row-cell">
+                                {processKey(key)}
+                            </TableCell>
+                            <TableCell className="File-table-row-cell">
+                                {processValue(value)}
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    );
+};
+
+export default AdditionalMetadataTable;

--- a/src/components/browseFiles/AdditionalMetadataTable.tsx
+++ b/src/components/browseFiles/AdditionalMetadataTable.tsx
@@ -15,6 +15,7 @@ export interface IFileDetailsTableProps {
 const AdditionalMetadataTable: React.FunctionComponent<
     IFileDetailsTableProps
 > = props => {
+    // Presentational formatting
     const processKey = (key: string) => key.replace("assays.", "");
     const processValue = (value: any) => {
         if (value instanceof Array) {
@@ -22,6 +23,16 @@ const AdditionalMetadataTable: React.FunctionComponent<
         }
         return value.toString();
     };
+
+    // For checking how nested in the data model a metadata key is
+    const countDots = (s: string) => (s.match(/\./g) || []).length;
+
+    // Format the metadata
+    const rows = map(props.metadata, (value, key) => ({
+        key: processKey(key),
+        value: processValue(value)
+    })).sort((a, b) => countDots(a.key) - countDots(b.key));
+
     return (
         <div className="File-table">
             <Table>
@@ -36,13 +47,13 @@ const AdditionalMetadataTable: React.FunctionComponent<
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {map(props.metadata, (value, key) => (
+                    {rows.map(({ key, value }) => (
                         <TableRow key={key}>
                             <TableCell className="File-table-row-cell">
-                                {processKey(key)}
+                                {key}
                             </TableCell>
                             <TableCell className="File-table-row-cell">
-                                {processValue(value)}
+                                {value}
                             </TableCell>
                         </TableRow>
                     ))}

--- a/src/components/browseFiles/FileDetailsPage.tsx
+++ b/src/components/browseFiles/FileDetailsPage.tsx
@@ -46,8 +46,8 @@ class FileDetailsPage extends React.Component<any, IFileDetailsPageState> {
                     </div>
                 )}
                 {this.state.file && (
-                    <Grid container={true} spacing={40} direction="column">
-                        <Grid item={true} xs={6}>
+                    <Grid container spacing={40} direction="row">
+                        <Grid item>
                             <Grid
                                 container={true}
                                 alignItems="flex-start"

--- a/src/components/browseFiles/FileDetailsPage.tsx
+++ b/src/components/browseFiles/FileDetailsPage.tsx
@@ -5,6 +5,7 @@ import { DataFile } from "../../model/file";
 import { Typography, CircularProgress, Grid, Button } from "@material-ui/core";
 import FileDetailsTable from "./FileDetailsTable";
 import { withIdToken } from "../../identity/AuthProvider";
+import AdditionalMetadataTable from "./AdditionalMetadataTable";
 
 export interface IFileDetailsPageState {
     file: DataFile | undefined;
@@ -45,7 +46,7 @@ class FileDetailsPage extends React.Component<any, IFileDetailsPageState> {
                     </div>
                 )}
                 {this.state.file && (
-                    <Grid container={true} spacing={40}>
+                    <Grid container={true} spacing={40} direction="column">
                         <Grid item={true} xs={6}>
                             <Grid
                                 container={true}
@@ -59,7 +60,7 @@ class FileDetailsPage extends React.Component<any, IFileDetailsPageState> {
                                         variant="h5"
                                         gutterBottom={true}
                                     >
-                                        Core File Properties:
+                                        Core File Properties
                                     </Typography>
                                 </Grid>
                                 <Grid item={true}>
@@ -75,6 +76,18 @@ class FileDetailsPage extends React.Component<any, IFileDetailsPageState> {
                             </Grid>
                             <FileDetailsTable file={this.state.file} />
                         </Grid>
+                        {this.state.file.additional_metadata && (
+                            <Grid item>
+                                <Typography variant="h5" gutterBottom={true}>
+                                    Additional Metadata
+                                </Typography>
+                                <AdditionalMetadataTable
+                                    metadata={
+                                        this.state.file.additional_metadata
+                                    }
+                                />
+                            </Grid>
+                        )}
                     </Grid>
                 )}
             </div>

--- a/src/model/file.ts
+++ b/src/model/file.ts
@@ -10,4 +10,7 @@ export interface DataFile {
     assay_type: string;
     data_format: string;
     download_link?: string;
+    additional_metadata?: {
+        [prop: string]: any;
+    };
 }


### PR DESCRIPTION
Not beautiful, but this gets the info on the page.
![Screen Shot 2019-10-08 at 10 37 00 AM](https://user-images.githubusercontent.com/14116434/66405110-a0593a80-e9b7-11e9-8bb5-322e5ac021d7.png)
