### PR TITLE
you can now search by additional metadata, not only filename

### DIFF
--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -118,7 +118,7 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
                         <Grid item={true} xs={9}>
                             <div className="File-search-border">
                                 <TextField
-                                    label="Search by file name"
+                                    label="Search"
                                     type="search"
                                     margin="normal"
                                     variant="outlined"

--- a/src/components/browseFiles/browseFilesUtil.test.ts
+++ b/src/components/browseFiles/browseFilesUtil.test.ts
@@ -96,38 +96,29 @@ test("Filters it correctly", () => {
     expect(
         filterFiles(files, ["DFCI-9999"], ["WES"], ["MAF", "VCF"], "dfci")
     ).toEqual([files[0]]);
-});
 
-test("Filters it correctly", () => {
     expect(filterFiles(files, [], [], [], "DFCI-9999")).toEqual([files[0]]);
-});
 
-test("Filters it correctly", () => {
     expect(filterFiles(files, [], [], [], "some_value")).toEqual([files[2]]);
-});
 
-test("Filters it correctly", () => {
     expect(filterFiles(files, [], [], [], "some_key")).toEqual([
         files[2],
         files[3]
     ]);
-});
 
-test("Filters it correctly", () => {
     expect(filterFiles(files, [], [], [], "other_key")).toEqual([
         files[4],
         files[5]
     ]);
-});
 
-// test space in search string as AND
-test("Filters it correctly", () => {
+    // test space in search string as AND
     expect(
         filterFiles(files, [], [], [], "other_key some_other_value")
     ).toEqual([files[5]]);
-});
 
-test("Filters it correctly", () => {
+    // AND between additional_metadata and filename
+    expect(filterFiles(files, [], [], [], "other_key vcf")).toEqual([files[5]]);
+
     expect(
         filterFiles(files, [], [], [], "other_key some_other_value NONEXISTING")
     ).toEqual([]);

--- a/src/components/browseFiles/browseFilesUtil.test.ts
+++ b/src/components/browseFiles/browseFilesUtil.test.ts
@@ -11,7 +11,7 @@ const files: DataFile[] = [
         file_size_bytes: 1234567,
         trial: "DFCI-9999",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "dfci-9999.maf",
+        object_url: "DFCI-9999/dfci-9999.maf",
         download_link: "download_url"
     },
     {
@@ -23,7 +23,7 @@ const files: DataFile[] = [
         file_size_bytes: 234,
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "test_uri",
+        object_url: "DFCI-1234/cimac-6521-001.fa",
         download_link: "download_url"
     },
     {
@@ -35,7 +35,7 @@ const files: DataFile[] = [
         file_size_bytes: 21,
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "test_uri",
+        object_url: "DFCI-1234/cimac-6521-002.fa",
         download_link: "download_url",
         additional_metadata: {
             some_key: "some_value"
@@ -50,7 +50,7 @@ const files: DataFile[] = [
         file_size_bytes: 22345,
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "test_uri",
+        object_url: "DFCI-1234/cimac-6521-003.fa",
         download_link: "download_url",
         additional_metadata: {
             some_key: "other_value"
@@ -65,7 +65,7 @@ const files: DataFile[] = [
         file_size_bytes: 12345545,
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "test_uri",
+        object_url: "DFCI-1234/cimac-6521-004.fa",
         download_link: "download_url",
         additional_metadata: {
             other_key: "other_value"
@@ -80,7 +80,7 @@ const files: DataFile[] = [
         file_size_bytes: 7654645,
         trial: "DFCI-9999",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
-        object_url: "test_uri",
+        object_url: "DFCI-9999/cimac-6521.vcf",
         download_link: "download_url",
         additional_metadata: {
             other_key: "some_other_value"
@@ -94,10 +94,16 @@ test("Returns the same file list if nothing is filtered", () => {
 
 test("Filters it correctly", () => {
     expect(
-        filterFiles(files, ["DFCI-9999"], ["WES"], ["MAF", "VCF"], "dfci")
+        filterFiles(
+            files,
+            ["DFCI-9999"],
+            ["WES"],
+            ["MAF", "VCF"],
+            "dfci-9999.maf"
+        )
     ).toEqual([files[0]]);
 
-    expect(filterFiles(files, [], [], [], "DFCI-9999")).toEqual([files[0]]);
+    expect(filterFiles(files, [], [], [], "dfci-9999.maf")).toEqual([files[0]]);
 
     expect(filterFiles(files, [], [], [], "some_value")).toEqual([files[2]]);
 

--- a/src/components/browseFiles/browseFilesUtil.test.ts
+++ b/src/components/browseFiles/browseFilesUtil.test.ts
@@ -36,7 +36,10 @@ const files: DataFile[] = [
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
         object_url: "test_uri",
-        download_link: "download_url"
+        download_link: "download_url",
+        additional_metadata: {
+            some_key: "some_value"
+        }
     },
     {
         id: 3,
@@ -48,7 +51,10 @@ const files: DataFile[] = [
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
         object_url: "test_uri",
-        download_link: "download_url"
+        download_link: "download_url",
+        additional_metadata: {
+            some_key: "other_value"
+        }
     },
     {
         id: 4,
@@ -60,7 +66,10 @@ const files: DataFile[] = [
         trial: "DFCI-1234",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
         object_url: "test_uri",
-        download_link: "download_url"
+        download_link: "download_url",
+        additional_metadata: {
+            other_key: "other_value"
+        }
     },
     {
         id: 5,
@@ -72,7 +81,10 @@ const files: DataFile[] = [
         trial: "DFCI-9999",
         uploaded_timestamp: new Date("2019-01-17T21:27:53.175496"),
         object_url: "test_uri",
-        download_link: "download_url"
+        download_link: "download_url",
+        additional_metadata: {
+            other_key: "some_other_value"
+        }
     }
 ];
 
@@ -84,6 +96,41 @@ test("Filters it correctly", () => {
     expect(
         filterFiles(files, ["DFCI-9999"], ["WES"], ["MAF", "VCF"], "dfci")
     ).toEqual([files[0]]);
+});
+
+test("Filters it correctly", () => {
+    expect(filterFiles(files, [], [], [], "DFCI-9999")).toEqual([files[0]]);
+});
+
+test("Filters it correctly", () => {
+    expect(filterFiles(files, [], [], [], "some_value")).toEqual([files[2]]);
+});
+
+test("Filters it correctly", () => {
+    expect(filterFiles(files, [], [], [], "some_key")).toEqual([
+        files[2],
+        files[3]
+    ]);
+});
+
+test("Filters it correctly", () => {
+    expect(filterFiles(files, [], [], [], "other_key")).toEqual([
+        files[4],
+        files[5]
+    ]);
+});
+
+// test space in search string as AND
+test("Filters it correctly", () => {
+    expect(
+        filterFiles(files, [], [], [], "other_key some_other_value")
+    ).toEqual([files[5]]);
+});
+
+test("Filters it correctly", () => {
+    expect(
+        filterFiles(files, [], [], [], "other_key some_other_value NONEXISTING")
+    ).toEqual([]);
 });
 
 test("Adds option to options list if it's not there", () => {

--- a/src/components/browseFiles/browseFilesUtil.ts
+++ b/src/components/browseFiles/browseFilesUtil.ts
@@ -34,7 +34,7 @@ export function filterFiles(
                 .every(
                     (searchToken: string) =>
                         url.includes(searchToken) ||
-                        additional_md.includes(searchToken)
+                        additionalMD.includes(searchToken)
                 );
         }
         return (

--- a/src/components/browseFiles/browseFilesUtil.ts
+++ b/src/components/browseFiles/browseFilesUtil.ts
@@ -24,9 +24,15 @@ export function filterFiles(
             isDataFormatMatch = selectedDataFormats.includes(file.data_format);
         }
         if (searchFilter.length > 0) {
-            isSearchFilterMatch = file.object_url
-                .toLowerCase()
-                .includes(searchFilter.toLowerCase());
+            isSearchFilterMatch = searchFilter.split(" ").every(
+                (searchToken: string) =>
+                    file.object_url
+                        .toLowerCase()
+                        .includes(searchFilter.toLowerCase()) ||
+                    JSON.stringify(file.additional_metadata || {})
+                        .toLowerCase()
+                        .includes(searchToken.toLowerCase())
+            );
         }
         return (
             isTrialIdMatch &&

--- a/src/components/browseFiles/browseFilesUtil.ts
+++ b/src/components/browseFiles/browseFilesUtil.ts
@@ -24,15 +24,18 @@ export function filterFiles(
             isDataFormatMatch = selectedDataFormats.includes(file.data_format);
         }
         if (searchFilter.length > 0) {
-            isSearchFilterMatch = searchFilter.split(" ").every(
-                (searchToken: string) =>
-                    file.object_url
-                        .toLowerCase()
-                        .includes(searchFilter.toLowerCase()) ||
-                    JSON.stringify(file.additional_metadata || {})
-                        .toLowerCase()
-                        .includes(searchToken.toLowerCase())
-            );
+            const additionalMD = JSON.stringify(
+                file.additional_metadata || {}
+            ).toLowerCase();
+            const url = file.object_url.toLowerCase();
+            isSearchFilterMatch = searchFilter
+                .split(" ")
+                .map(t => t.toLowerCase())
+                .every(
+                    (searchToken: string) =>
+                        url.includes(searchToken) ||
+                        additional_md.includes(searchToken)
+                );
         }
         return (
             isTrialIdMatch &&


### PR DESCRIPTION
and have multi-criteria (with logical AND) by splitting search query to tokens by space. 