### PR TITLE
File browser filter routing

### DIFF
--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -10,24 +10,20 @@ import FileTable from "./FileTable";
 import { getFiles } from "../../api/api";
 import Loader from "../generic/Loader";
 import { withIdToken } from "../../identity/AuthProvider";
+import { RouteComponentProps } from "react-router";
 
 export interface IBrowseFilesPageState {
     files: DataFile[] | undefined;
     trials: string[] | undefined;
-    selectedTrialIds: string[];
-    selectedExperimentalStrategies: string[];
-    selectedDataFormats: string[];
-    searchFilter: string;
 }
 
-class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
+class BrowseFilesPage extends React.Component<
+    RouteComponentProps & { token: string },
+    IBrowseFilesPageState
+> {
     state: IBrowseFilesPageState = {
         files: undefined,
-        trials: undefined,
-        searchFilter: "",
-        selectedDataFormats: [],
-        selectedExperimentalStrategies: [],
-        selectedTrialIds: []
+        trials: undefined
     };
 
     componentDidMount() {
@@ -51,29 +47,24 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
     }
 
     @autobind
-    private handleTrialIdChange(trialId: string) {
-        this.setState({
-            selectedTrialIds: changeOption(this.state.selectedTrialIds, trialId)
-        });
-    }
+    private handleArrayParamChange(
+        param: "protocol_id" | "type" | "data_format",
+        value: string
+    ) {
+        const params = new URLSearchParams(this.props.location.search);
+        const valuesStr = params.get(param);
 
-    @autobind
-    private handleExperimentalStrategyChange(experimentalStrategy: string) {
-        this.setState({
-            selectedExperimentalStrategies: changeOption(
-                this.state.selectedExperimentalStrategies,
-                experimentalStrategy
-            )
-        });
-    }
+        if (valuesStr !== null) {
+            const values: string[] = JSON.parse(valuesStr);
+            const newValues = changeOption(values, value);
+            params.set(param, JSON.stringify(newValues));
+        } else {
+            params.set(param, JSON.stringify([value]));
+        }
 
-    @autobind
-    private handleDataFormatChange(dataFormat: string) {
-        this.setState({
-            selectedDataFormats: changeOption(
-                this.state.selectedDataFormats,
-                dataFormat
-            )
+        this.props.history.push({
+            ...this.props.location,
+            search: params.toString()
         });
     }
 
@@ -81,10 +72,23 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
     private handleSearchFilterChange(
         event: React.ChangeEvent<HTMLInputElement>
     ) {
-        this.setState({ searchFilter: event.target.value });
+        const params = new URLSearchParams(this.props.location.search);
+        params.set("search", event.target.value);
+        this.props.history.push({
+            ...this.props.location,
+            search: params.toString()
+        });
     }
 
     public render() {
+        const params = new URLSearchParams(this.props.location.search);
+        const searchFilter = params.get("search") || "";
+        const selectedTrialIds = JSON.parse(params.get("protocol_id") || "[]");
+        const selectedDataFormats = JSON.parse(
+            params.get("data_format") || "[]"
+        );
+        const selectedTypes = JSON.parse(params.get("type") || "[]");
+
         return (
             <div className="Browse-files-page">
                 {!this.state.files && <Loader />}
@@ -99,20 +103,39 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
                     <Grid container={true} spacing={3}>
                         <Grid item={true} xs={3}>
                             <FileFilter
-                                trialIds={_.uniq(
-                                    _.map(this.state.files, "trial")
-                                )}
-                                experimentalStrategies={_.uniq(
-                                    _.map(this.state.files, "assay_type")
-                                )}
-                                dataFormats={_.uniq(
-                                    _.map(this.state.files, "data_format")
-                                )}
-                                onTrialIdChange={this.handleTrialIdChange}
-                                onExperimentalStrategyChange={
-                                    this.handleExperimentalStrategyChange
+                                trialIds={{
+                                    options: _.uniq(
+                                        _.map(this.state.files, "trial")
+                                    ),
+                                    checked: selectedTrialIds
+                                }}
+                                experimentalStrategies={{
+                                    options: _.uniq(
+                                        _.map(this.state.files, "assay_type")
+                                    ),
+                                    checked: selectedTypes
+                                }}
+                                dataFormats={{
+                                    options: _.uniq(
+                                        _.map(this.state.files, "data_format")
+                                    ),
+                                    checked: selectedDataFormats
+                                }}
+                                onTrialIdChange={tid =>
+                                    this.handleArrayParamChange(
+                                        "protocol_id",
+                                        tid
+                                    )
                                 }
-                                onDataFormatChange={this.handleDataFormatChange}
+                                onExperimentalStrategyChange={typ =>
+                                    this.handleArrayParamChange("type", typ)
+                                }
+                                onDataFormatChange={dataFormat =>
+                                    this.handleArrayParamChange(
+                                        "data_format",
+                                        dataFormat
+                                    )
+                                }
                             />
                         </Grid>
                         <Grid item={true} xs={9}>
@@ -122,7 +145,7 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
                                     type="search"
                                     margin="normal"
                                     variant="outlined"
-                                    value={this.state.searchFilter}
+                                    value={searchFilter}
                                     className="File-search"
                                     InputProps={{
                                         className: "File-search-input"
@@ -137,10 +160,10 @@ class BrowseFilesPage extends React.Component<any, IBrowseFilesPageState> {
                                 history={this.props.history}
                                 files={filterFiles(
                                     this.state.files,
-                                    this.state.selectedTrialIds,
-                                    this.state.selectedExperimentalStrategies,
-                                    this.state.selectedDataFormats,
-                                    this.state.searchFilter
+                                    selectedTrialIds,
+                                    selectedTypes,
+                                    selectedDataFormats,
+                                    searchFilter
                                 )}
                                 trials={this.state.trials!}
                             />

--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -50,12 +50,18 @@ class BrowseFilesPage extends React.Component<
     private handleArrayParamChange(
         params: URLSearchParams,
         values: string[],
-        param: "protocol_id" | "type" | "data_format",
+        paramKey: "protocol_id" | "type" | "data_format",
         value: string
     ) {
         const newValues = changeOption(values, value);
-        params.set(param, JSON.stringify(newValues));
 
+        // Clear all old values for this param then set new values
+        params.delete(paramKey);
+        for (const val of newValues) {
+            params.append(paramKey, val);
+        }
+
+        // Apply search string updates to the current location
         this.props.history.push({
             ...this.props.location,
             search: params.toString()
@@ -78,11 +84,9 @@ class BrowseFilesPage extends React.Component<
         // Extract current filter parameters from the URL
         const params = new URLSearchParams(this.props.location.search);
         const searchFilter = params.get("search") || "";
-        const selectedTrialIds = JSON.parse(params.get("protocol_id") || "[]");
-        const selectedDataFormats = JSON.parse(
-            params.get("data_format") || "[]"
-        );
-        const selectedTypes = JSON.parse(params.get("type") || "[]");
+        const selectedTrialIds = params.getAll("protocol_id");
+        const selectedDataFormats = params.getAll("data_format");
+        const selectedTypes = params.getAll("type");
 
         return (
             <div className="Browse-files-page">

--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -48,19 +48,13 @@ class BrowseFilesPage extends React.Component<
 
     @autobind
     private handleArrayParamChange(
+        params: URLSearchParams,
+        values: string[],
         param: "protocol_id" | "type" | "data_format",
         value: string
     ) {
-        const params = new URLSearchParams(this.props.location.search);
-        const valuesStr = params.get(param);
-
-        if (valuesStr !== null) {
-            const values: string[] = JSON.parse(valuesStr);
-            const newValues = changeOption(values, value);
-            params.set(param, JSON.stringify(newValues));
-        } else {
-            params.set(param, JSON.stringify([value]));
-        }
+        const newValues = changeOption(values, value);
+        params.set(param, JSON.stringify(newValues));
 
         this.props.history.push({
             ...this.props.location,
@@ -70,9 +64,9 @@ class BrowseFilesPage extends React.Component<
 
     @autobind
     private handleSearchFilterChange(
-        event: React.ChangeEvent<HTMLInputElement>
+        event: React.ChangeEvent<HTMLInputElement>,
+        params: URLSearchParams
     ) {
-        const params = new URLSearchParams(this.props.location.search);
         params.set("search", event.target.value);
         this.props.history.push({
             ...this.props.location,
@@ -81,6 +75,7 @@ class BrowseFilesPage extends React.Component<
     }
 
     public render() {
+        // Extract current filter parameters from the URL
         const params = new URLSearchParams(this.props.location.search);
         const searchFilter = params.get("search") || "";
         const selectedTrialIds = JSON.parse(params.get("protocol_id") || "[]");
@@ -123,15 +118,24 @@ class BrowseFilesPage extends React.Component<
                                 }}
                                 onTrialIdChange={tid =>
                                     this.handleArrayParamChange(
+                                        params,
+                                        selectedTrialIds,
                                         "protocol_id",
                                         tid
                                     )
                                 }
                                 onExperimentalStrategyChange={typ =>
-                                    this.handleArrayParamChange("type", typ)
+                                    this.handleArrayParamChange(
+                                        params,
+                                        selectedTypes,
+                                        "type",
+                                        typ
+                                    )
                                 }
                                 onDataFormatChange={dataFormat =>
                                     this.handleArrayParamChange(
+                                        params,
+                                        selectedDataFormats,
                                         "data_format",
                                         dataFormat
                                     )
@@ -153,7 +157,11 @@ class BrowseFilesPage extends React.Component<
                                     InputLabelProps={{
                                         className: "File-search-label"
                                     }}
-                                    onChange={this.handleSearchFilterChange}
+                                    onChange={(
+                                        e: React.ChangeEvent<HTMLInputElement>
+                                    ) =>
+                                        this.handleSearchFilterChange(e, params)
+                                    }
                                 />
                             </div>
                             <FileTable

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -1,11 +1,13 @@
 import { Grid } from "@material-ui/core";
 import * as React from "react";
-import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
+import FileFilterCheckboxGroup, {
+    IFilterConfig
+} from "./FileFilterCheckboxGroup";
 
 export interface IFileFilterProps {
-    trialIds: string[];
-    experimentalStrategies: string[];
-    dataFormats: string[];
+    trialIds: IFilterConfig;
+    experimentalStrategies: IFilterConfig;
+    dataFormats: IFilterConfig;
     onTrialIdChange: (trialId: string) => void;
     onExperimentalStrategyChange: (experimentalStrategy: string) => void;
     onDataFormatChange: (dataFormat: string) => void;
@@ -19,21 +21,21 @@ export default class FileFilter extends React.Component<IFileFilterProps, {}> {
                     <Grid item={true} xs={12}>
                         <FileFilterCheckboxGroup
                             title="Protocol Identifier"
-                            options={this.props.trialIds}
+                            config={this.props.trialIds}
                             onChange={this.props.onTrialIdChange}
                         />
                     </Grid>
                     <Grid item={true} xs={12}>
                         <FileFilterCheckboxGroup
                             title="Type"
-                            options={this.props.experimentalStrategies}
+                            config={this.props.experimentalStrategies}
                             onChange={this.props.onExperimentalStrategyChange}
                         />
                     </Grid>
                     <Grid item={true} xs={12}>
                         <FileFilterCheckboxGroup
                             title="Format"
-                            options={this.props.dataFormats}
+                            config={this.props.dataFormats}
                             onChange={this.props.onDataFormatChange}
                         />
                     </Grid>

--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -8,9 +8,14 @@ import Checkbox from "@material-ui/core/Checkbox";
 import autobind from "autobind-decorator";
 import * as React from "react";
 
+export interface IFilterConfig {
+    options: string[];
+    checked: string[];
+}
+
 export interface IFileFilterCheckboxGroupProps {
     title: string;
-    options: string[];
+    config: IFilterConfig;
     onChange: (option: string) => void;
 }
 
@@ -33,7 +38,7 @@ export default class FileFilterCheckboxGroup extends React.Component<
                 </Toolbar>
                 <div className="File-filter-checkboxes">
                     <FormGroup>
-                        {this.props.options.map((dataFormat: string) => {
+                        {this.props.config.options.map((dataFormat: string) => {
                             return (
                                 <FormControlLabel
                                     key={dataFormat}
@@ -41,6 +46,9 @@ export default class FileFilterCheckboxGroup extends React.Component<
                                     control={
                                         <Checkbox
                                             value={dataFormat}
+                                            checked={this.props.config.checked.includes(
+                                                dataFormat
+                                            )}
                                             onChange={this.handleChange}
                                             className="File-filter-checkbox"
                                         />

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -37,6 +37,14 @@ export default class Footer extends React.Component<{}, {}> {
                                 </MuiLink>
                             </RouterLink>
                         </div>
+                        <div>
+                            <MuiLink
+                                underline="none"
+                                href="https://github.com/cimac-cidc"
+                            >
+                                GitHub
+                            </MuiLink>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/identity/AuthProvider.tsx
+++ b/src/identity/AuthProvider.tsx
@@ -170,7 +170,10 @@ const AuthProvider: React.FunctionComponent<RouteComponentProps> = props => {
                         authResult.accessToken &&
                         authResult.idToken
                     ) {
-                        sessionSetter(authResult, props.location.pathname);
+                        sessionSetter(
+                            authResult,
+                            props.location.pathname + props.location.search
+                        );
                     } else {
                         if (err) {
                             console.error(err);


### PR DESCRIPTION
Store filters as search params on the `/browse-files` route to make searches shareable and search history browseable.

For example:
~`.../browse-files?protocol_id=[%22staging_1%22]&type=[%22olink%22%2C%22participants+info%22]&search=chip_&data_format=[%22npx%22%2C%22csv%22]`~
**Edit** `.../browse-files?protocol_id=staging_1&type=olink&type=participants+info&data_format=npx&data_format=csv&search=chip_`
<img width="1792" alt="Screen Shot 2019-10-10 at 3 56 40 PM" src="https://user-images.githubusercontent.com/14116434/66601870-db559c80-eb76-11e9-80fe-8afccba6eaab.png">

