### PR TITLE
Remove TrialMetadata from DataContext

### DIFF
--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -57,6 +57,8 @@ class BrowseFilesPage extends React.Component<
         const selectedDataFormats = params.getAll("data_format");
         const selectedTypes = params.getAll("type");
 
+        const trials = _.uniq(this.props.files.map(f => f.trial));
+
         return (
             <div className="Browse-files-page">
                 {this.props.files.length === 0 && (
@@ -171,9 +173,7 @@ class BrowseFilesPage extends React.Component<
                                         selectedDataFormats,
                                         searchFilter
                                     )}
-                                    trials={this.props.trials.map(
-                                        trial => trial.trial_id
-                                    )}
+                                    trials={trials}
                                 />
                             )}
                             {this.props.dataStatus === "failed" && (

--- a/src/components/data/DataProvider.tsx
+++ b/src/components/data/DataProvider.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import { Trial } from "../../model/trial";
 import { DataFile } from "../../model/file";
 import { AuthContext } from "../identity/AuthProvider";
-import { getTrials, getFiles } from "../../api/api";
+import { getFiles } from "../../api/api";
 import Loader from "../generic/Loader";
 
 export interface IDataContext {
-    trials: Trial[];
     files: DataFile[];
     dataStatus: "fetching" | "fetched" | "failed";
     refreshData: () => void;
@@ -19,7 +17,6 @@ export const DataContext = React.createContext<IDataContext | undefined>(
 export const DataProvider: React.FunctionComponent = props => {
     const authContext = React.useContext(AuthContext);
 
-    const [trials, setTrials] = React.useState<Trial[] | undefined>(undefined);
     const [files, setFiles] = React.useState<DataFile[] | undefined>(undefined);
     const [dataStatus, setDataStatus] = React.useState<
         IDataContext["dataStatus"]
@@ -28,18 +25,18 @@ export const DataProvider: React.FunctionComponent = props => {
     const refreshData = () => {
         if (authContext) {
             setDataStatus("fetching");
-            Promise.all([
-                getTrials(authContext.idToken).then(ts => setTrials(ts)),
-                getFiles(authContext.idToken).then(fs => setFiles(fs))
-            ])
-                .then(() => setDataStatus("fetched"))
+            getFiles(authContext.idToken)
+                .then(fs => {
+                    setFiles(fs);
+                    setDataStatus("fetched");
+                })
                 .catch(() => setDataStatus("failed"));
         }
     };
 
     React.useEffect(refreshData, []);
 
-    const value = trials && files && { trials, files, dataStatus, refreshData };
+    const value = files && { files, dataStatus, refreshData };
 
     return (
         <DataContext.Provider value={value}>


### PR DESCRIPTION
Only `cidc-admins` have permissions to access the `trial_metadata` resource, so requests for this resource shouldn't live in `DataProvider`.