### PR TITLE
Disable sticky subheaders on assays page

### DIFF
--- a/src/components/assays/AssaysPage.tsx
+++ b/src/components/assays/AssaysPage.tsx
@@ -36,12 +36,16 @@ const AssaysPage: React.FunctionComponent<RouteComponentProps> = props => {
             <Grid container direction="row">
                 <Grid item lg={2}>
                     <List style={{ paddingTop: 0 }}>
-                        <ListSubheader>General Overview</ListSubheader>
+                        <ListSubheader disableSticky>
+                            General Overview
+                        </ListSubheader>
                         <AssayListItem
                             title="CLI Instructions"
                             path={`/assays/${paths.cli}`}
                         />
-                        <ListSubheader>Assay-Specific Docs</ListSubheader>
+                        <ListSubheader disableSticky>
+                            Assay-Specific Docs
+                        </ListSubheader>
                         <AssayListItem
                             title="Olink"
                             path={`/assays/${paths.olink}`}


### PR DESCRIPTION
MUI list subheaders are sticky by default 🤷‍♂:
![Screen Shot 2019-10-18 at 12 20 09 PM](https://user-images.githubusercontent.com/14116434/67122742-7b857400-f1bc-11e9-9ccd-19fc467921f4.png)

This PR disables stickiness.