### PR TITLE
Server-side pagination in the file browser

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -59,10 +59,23 @@ function _transformFile(file: DataFile): DataFile {
     return { ...file, data_format: file.data_format.toLowerCase() };
 }
 
-function getFiles(token: string): Promise<DataFile[]> {
-    return _getItems<DataFile>(token, "downloadable_files").then(trials =>
-        trials.map(_transformFile)
-    );
+export interface IDataWithMeta<D> {
+    data: D;
+    meta: {
+        total: number;
+    };
+}
+
+function getFiles(
+    token: string,
+    params?: any
+): Promise<IDataWithMeta<DataFile[]>> {
+    return getApiClient(token)
+        .get("downloadable_files", { params })
+        .then(res => {
+            const { _items, _meta: meta } = _extractItem(res);
+            return { data: _items.map(_transformFile), meta };
+        });
 }
 
 function getSingleFile(

--- a/src/components/browseFiles/BrowseFilesPage.tsx
+++ b/src/components/browseFiles/BrowseFilesPage.tsx
@@ -1,4 +1,4 @@
-import { Grid, Typography, Button } from "@material-ui/core";
+import { Grid, Typography } from "@material-ui/core";
 import uniq from "lodash/uniq";
 import * as React from "react";
 import FileFilter from "./FileFilter";
@@ -6,7 +6,6 @@ import FileTable from "./FileTable";
 import { withIdToken } from "../identity/AuthProvider";
 import { RouteComponentProps } from "react-router";
 import { withData, IDataContext } from "../data/DataProvider";
-import { Refresh } from "@material-ui/icons";
 import Loader from "../generic/Loader";
 import { StringParam, ArrayParam, useQueryParams } from "use-query-params";
 
@@ -16,19 +15,7 @@ export const filterConfig = {
     data_format: ArrayParam,
     type: ArrayParam
 };
-type Filters = ReturnType<typeof useQueryParams>[0];
-
-export const filtersToWhereClause = (filters: Filters): string => {
-    const arraySubclause = (ids: any, key: string) =>
-        !!ids && `(${ids.map((id: string) => `${key}=="${id}"`).join(" or ")})`;
-    const subclauses = [
-        arraySubclause(filters.protocol_id, "trial"),
-        arraySubclause(filters.type, "assay_type"),
-        arraySubclause(filters.data_format, "data_format")
-    ];
-
-    return subclauses.filter(c => !!c).join(" and ");
-};
+export type Filters = ReturnType<typeof useQueryParams>[0];
 
 const BrowseFilesPage: React.FC<
     RouteComponentProps & { token: string } & IDataContext
@@ -106,7 +93,7 @@ const BrowseFilesPage: React.FC<
                             width: `calc(100% - ${filterWidth}px)`
                         }}
                     >
-                        <Grid
+                        {/*<Grid
                             container
                             wrap="nowrap"
                             direction="row"
@@ -114,7 +101,7 @@ const BrowseFilesPage: React.FC<
                             alignItems="center"
                         >
                             <Grid item>
-                                {/*
+
                                 Free text search is disabled for now, pending
                                 engineering decisions about how to do this server-side.
 
@@ -130,7 +117,7 @@ const BrowseFilesPage: React.FC<
                                     ) =>
                                         updateFilters("search", e.target.value)
                                     }
-                                />*/}
+                                />
                             </Grid>
                             <Grid item>
                                 <Button
@@ -141,7 +128,7 @@ const BrowseFilesPage: React.FC<
                                     Refresh
                                 </Button>
                             </Grid>
-                        </Grid>
+                        </Grid>*/}
                         {props.dataStatus === "fetching" && <Loader />}
                         {props.dataStatus === "fetched" && (
                             <FileTable history={props.history} />

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -69,7 +69,6 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
     const sortHeader = headers.filter(h => h.active)[0];
 
     React.useEffect(() => {
-        // TODO: handle total_count for this query!
         getFiles(props.token, {
             page: page + 1, // eve-sqlalchemy pagination starts at 1
             where: filtersToWhereClause(filters),

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -28,7 +28,7 @@ export interface IFileTableProps {
     history: any;
 }
 
-const filtersToWhereClause = (filters: Filters): string => {
+export const filtersToWhereClause = (filters: Filters): string => {
     const arraySubclause = (ids: any, key: string) =>
         !!ids && `(${ids.map((id: string) => `${key}=="${id}"`).join(" or ")})`;
     const subclauses = [
@@ -40,7 +40,7 @@ const filtersToWhereClause = (filters: Filters): string => {
     return subclauses.filter(c => !!c).join(" and ");
 };
 
-const headerToSortClause = (header: IHeader): string => {
+export const headerToSortClause = (header: IHeader): string => {
     return `[("${header.key}", ${header.direction === "asc" ? 1 : -1})]`;
 };
 

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -4,7 +4,7 @@ import { LOCALE, DATE_OPTIONS } from "../../util/constants";
 import { colors } from "../../rootStyles";
 import PaginatedTable, { IHeader } from "../generic/PaginatedTable";
 import { makeStyles } from "@material-ui/core";
-import { filtersToWhereClause, filterConfig } from "./BrowseFilesPage";
+import { filterConfig, Filters } from "./BrowseFilesPage";
 import { useQueryParams } from "use-query-params";
 import { getFiles, IDataWithMeta } from "../../api/api";
 import { withIdToken } from "../identity/AuthProvider";
@@ -27,6 +27,18 @@ const useStyles = makeStyles({
 export interface IFileTableProps {
     history: any;
 }
+
+export const filtersToWhereClause = (filters: Filters): string => {
+    const arraySubclause = (ids: any, key: string) =>
+        !!ids && `(${ids.map((id: string) => `${key}=="${id}"`).join(" or ")})`;
+    const subclauses = [
+        arraySubclause(filters.protocol_id, "trial"),
+        arraySubclause(filters.type, "assay_type"),
+        arraySubclause(filters.data_format, "data_format")
+    ];
+
+    return subclauses.filter(c => !!c).join(" and ");
+};
 
 const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
     const classes = useStyles();
@@ -64,7 +76,6 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
     return (
         <div className={classes.root}>
             <PaginatedTable
-                sortable
                 count={data ? data.meta.total : 0}
                 page={page}
                 onChangePage={p => setPage(p)}

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -2,9 +2,14 @@ import React from "react";
 import { DataFile } from "../../model/file";
 import { LOCALE, DATE_OPTIONS } from "../../util/constants";
 import { colors } from "../../rootStyles";
-import PaginatedTable, { ISortConfig } from "../generic/PaginatedTable";
-import orderBy from "lodash/orderBy";
+import PaginatedTable, { IHeader } from "../generic/PaginatedTable";
 import { makeStyles } from "@material-ui/core";
+import { filtersToWhereClause, filterConfig } from "./BrowseFilesPage";
+import { useQueryParams } from "use-query-params";
+import { getFiles, IDataWithMeta } from "../../api/api";
+import { withIdToken } from "../identity/AuthProvider";
+
+const FILE_TABLE_PAGE_SIZE = 15;
 
 const useStyles = makeStyles({
     root: {
@@ -20,51 +25,54 @@ const useStyles = makeStyles({
 });
 
 export interface IFileTableProps {
-    files: DataFile[];
-    trials: string[];
     history: any;
 }
 
-const FileTable: React.FC<IFileTableProps> = props => {
+const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
     const classes = useStyles();
+    const filters = useQueryParams(filterConfig)[0];
 
-    const uploadTimeHeader = {
-        key: "uploaded_timestamp",
-        label: "Date/Time Uploaded",
-        format: (ts: number) =>
-            new Date(ts).toLocaleString(LOCALE, DATE_OPTIONS),
-        sortBy: (f: DataFile) => new Date(f.uploaded_timestamp)
-    };
+    const [page, setPage] = React.useState<number>(0);
+    const [data, setData] = React.useState<
+        IDataWithMeta<DataFile[]> | undefined
+    >(undefined);
+
+    React.useEffect(() => {
+        // TODO: handle total_count for this query!
+        getFiles(props.token, {
+            page: page + 1, // eve-sqlalchemy pagination starts at 1
+            where: filtersToWhereClause(filters),
+            max_results: FILE_TABLE_PAGE_SIZE
+        }).then(files => setData(files));
+    }, [filters, page, props.token]);
+
     const headers = [
         { key: "object_url", label: "File Name" },
-        { key: "trial", label: "Protocol Identifier" },
         { key: "assay_type", label: "Type" },
         { key: "data_format", label: "Format" },
-        uploadTimeHeader
+        {
+            key: "uploaded_timestamp",
+            label: "Date/Time Uploaded",
+            format: (ts: number) =>
+                new Date(ts).toLocaleString(LOCALE, DATE_OPTIONS),
+            sortBy: (f: DataFile) => new Date(f.uploaded_timestamp),
+            active: true,
+            direction: "desc"
+        } as IHeader
     ];
 
     return (
         <div className={classes.root}>
             <PaginatedTable
+                sortable
+                count={data ? data.meta.total : 0}
+                page={page}
+                onChangePage={p => setPage(p)}
+                rowsPerPage={FILE_TABLE_PAGE_SIZE}
                 headers={headers}
-                totalCount={props.files.length}
-                initialSorting={{ ...uploadTimeHeader, direction: "desc" }}
+                data={data && data.data}
                 getRowKey={row => row.id}
-                getNextN={(
-                    n: number,
-                    startingAt: number,
-                    sortConfig?: ISortConfig
-                ) => {
-                    // `sortConfig` will be defined here
-                    return sortConfig
-                        ? orderBy(
-                              props.files,
-                              sortConfig.sortBy || sortConfig.key,
-                              sortConfig.direction
-                          ).slice(startingAt, startingAt + n)
-                        : [];
-                }}
-                handleRowClick={row =>
+                onClickRow={row =>
                     props.history.push("/file-details/" + row.id)
                 }
             />
@@ -72,4 +80,4 @@ const FileTable: React.FC<IFileTableProps> = props => {
     );
 };
 
-export default FileTable;
+export default withIdToken<IFileTableProps>(FileTable);

--- a/src/components/browseFiles/__tests__/FileTable.ts
+++ b/src/components/browseFiles/__tests__/FileTable.ts
@@ -1,0 +1,29 @@
+import { filtersToWhereClause, headerToSortClause } from "../FileTable";
+
+test("filtersToWhereClause", () => {
+    expect(filtersToWhereClause({})).toBe("");
+    expect(filtersToWhereClause({ type: [1, 2] })).toBe(
+        '(assay_type=="1" or assay_type=="2")'
+    );
+    expect(filtersToWhereClause({ type: [1, 2], protocol_id: undefined })).toBe(
+        '(assay_type=="1" or assay_type=="2")'
+    );
+    expect(
+        filtersToWhereClause({
+            type: [1, 2],
+            protocol_id: ["a", "b"],
+            data_format: ["wes"]
+        })
+    ).toBe(
+        '(trial=="a" or trial=="b") and (assay_type=="1" or assay_type=="2") and (data_format=="wes")'
+    );
+});
+
+test("headerToSortClause", () => {
+    expect(headerToSortClause({ key: "foo", direction: "asc" })).toBe(
+        '[("foo", 1)]'
+    );
+    expect(headerToSortClause({ key: "foo", direction: "desc" })).toBe(
+        '[("foo", -1)]'
+    );
+});

--- a/src/components/browseFiles/__tests__/browseFilesUtil.ts
+++ b/src/components/browseFiles/__tests__/browseFilesUtil.ts
@@ -1,5 +1,5 @@
-import { changeOption, filterFiles } from "./browseFilesUtil";
-import { DataFile } from "../../model/file";
+import { changeOption, filterFiles } from "../browseFilesUtil";
+import { DataFile } from "../../../model/file";
 
 const files: DataFile[] = [
     {

--- a/src/components/data/DataProvider.tsx
+++ b/src/components/data/DataProvider.tsx
@@ -30,7 +30,7 @@ export const DataProvider: React.FunctionComponent = props => {
             setDataStatus("fetching");
             getFiles(authContext.idToken)
                 .then(fs => {
-                    setFiles(fs);
+                    setFiles(fs.data);
                     setDataStatus("fetched");
                 })
                 .catch(() => setDataStatus("failed"));

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -6,12 +6,13 @@ import {
     TableHead,
     TableRow,
     TableSortLabel,
-    TablePagination
+    TablePagination,
+    Grid,
+    Typography
 } from "@material-ui/core";
 
 export interface IPaginatedTableProps {
     headers?: IHeader[];
-    sortable?: boolean;
     data?: DataRow[];
     count: number;
     page: number;
@@ -36,6 +37,9 @@ export interface IHeader {
 export type DataRow = any;
 
 const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
+    const [dataWillChange, setDataWillChange] = React.useState<boolean>(false);
+    React.useEffect(() => setDataWillChange(false), [props.data]);
+
     return (
         <>
             <Table size="small">
@@ -44,7 +48,7 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         <TableRow>
                             {props.headers.map(header => (
                                 <TableCell key={header.key}>
-                                    {props.sortable ? (
+                                    {props.onClickHeader ? (
                                         <TableSortLabel
                                             active={header.active}
                                             direction={header.direction}
@@ -63,9 +67,9 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         </TableRow>
                     </TableHead>
                 )}
-                <TableBody>
-                    {props.data &&
-                        props.data.map(row => (
+                {props.data ? (
+                    <TableBody>
+                        {props.data.map(row => (
                             <TableRow
                                 key={props.getRowKey(row)}
                                 hover={!!props.onClickRow}
@@ -92,7 +96,23 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                                       ))}
                             </TableRow>
                         ))}
-                </TableBody>
+                    </TableBody>
+                ) : (
+                    <Grid
+                        container
+                        style={{ padding: "1em" }}
+                        justify="center"
+                        alignItems="center"
+                    >
+                        <Grid item>
+                            <Typography color="textSecondary">
+                                {props.data === undefined
+                                    ? "Loading..."
+                                    : "No data found for these filters."}
+                            </Typography>
+                        </Grid>
+                    </Grid>
+                )}
             </Table>
             <TablePagination
                 component="div"
@@ -100,7 +120,14 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                 rowsPerPage={props.rowsPerPage}
                 rowsPerPageOptions={[]}
                 page={props.page}
-                onChangePage={(_, n) => props.onChangePage(n)}
+                onChangePage={(_, n) => {
+                    setDataWillChange(true);
+                    props.onChangePage(n);
+                }}
+                backIconButtonProps={{
+                    disabled: dataWillChange || props.page === 0
+                }}
+                nextIconButtonProps={{ disabled: dataWillChange }}
             />
         </>
     );

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -7,9 +7,15 @@ import {
     TableRow,
     TableSortLabel,
     TablePagination,
-    Grid,
-    Typography
+    Typography,
+    makeStyles
 } from "@material-ui/core";
+
+const useStyles = makeStyles({
+    message: {
+        margin: "1rem"
+    }
+});
 
 export interface IPaginatedTableProps {
     headers?: IHeader[];
@@ -36,6 +42,8 @@ export interface IHeader {
 export type DataRow = any;
 
 const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
+    const classes = useStyles();
+
     const [dataWillChange, setDataWillChange] = React.useState<boolean>(true);
     React.useEffect(() => setDataWillChange(false), [props.data]);
 
@@ -105,20 +113,14 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         ))}
                     </TableBody>
                 ) : (
-                    <Grid
-                        container
-                        style={{ padding: "1em" }}
-                        justify="center"
-                        alignItems="center"
+                    <Typography
+                        className={classes.message}
+                        color="textSecondary"
                     >
-                        <Grid item>
-                            <Typography color="textSecondary">
-                                {props.data === undefined
-                                    ? "Loading..."
-                                    : "No data found for these filters."}
-                            </Typography>
-                        </Grid>
-                    </Grid>
+                        {props.data === undefined
+                            ? "Loading..."
+                            : "No data found for these filters."}
+                    </Typography>
                 )}
             </Table>
             <TablePagination

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -27,7 +27,6 @@ export interface IPaginatedTableProps {
 export interface IHeader {
     key: string;
     label: string;
-    sortBy?: (row: any) => any;
     format?: (v: any) => string;
     active?: boolean;
     direction?: "asc" | "desc";
@@ -37,8 +36,14 @@ export interface IHeader {
 export type DataRow = any;
 
 const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
-    const [dataWillChange, setDataWillChange] = React.useState<boolean>(false);
+    const [dataWillChange, setDataWillChange] = React.useState<boolean>(true);
     React.useEffect(() => setDataWillChange(false), [props.data]);
+
+    const backDisabled = dataWillChange || props.page === 0;
+    const nextDisabled =
+        dataWillChange ||
+        props.data === undefined ||
+        props.data.length <= props.count;
 
     return (
         <>
@@ -52,10 +57,12 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                                         <TableSortLabel
                                             active={header.active}
                                             direction={header.direction}
-                                            onClick={() =>
-                                                props.onClickHeader &&
-                                                props.onClickHeader(header)
-                                            }
+                                            onClick={() => {
+                                                if (props.onClickHeader) {
+                                                    setDataWillChange(true);
+                                                    props.onClickHeader(header);
+                                                }
+                                            }}
                                         >
                                             {header.label}
                                         </TableSortLabel>
@@ -67,7 +74,7 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         </TableRow>
                     </TableHead>
                 )}
-                {props.data ? (
+                {props.data && props.data.length > 0 ? (
                     <TableBody>
                         {props.data.map(row => (
                             <TableRow
@@ -124,10 +131,8 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                     setDataWillChange(true);
                     props.onChangePage(n);
                 }}
-                backIconButtonProps={{
-                    disabled: dataWillChange || props.page === 0
-                }}
-                nextIconButtonProps={{ disabled: dataWillChange }}
+                backIconButtonProps={{ disabled: backDisabled }}
+                nextIconButtonProps={{ disabled: nextDisabled }}
             />
         </>
     );

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -48,10 +48,9 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
     React.useEffect(() => setDataWillChange(false), [props.data]);
 
     const backDisabled = dataWillChange || props.page === 0;
+    const isLastPage = props.count - props.rowsPerPage * (props.page + 1) < 0;
     const nextDisabled =
-        dataWillChange ||
-        props.data === undefined ||
-        props.data.length <= props.count;
+        dataWillChange || props.data === undefined || isLastPage;
 
     return (
         <>

--- a/src/components/userAccount/AdminMenu.tsx
+++ b/src/components/userAccount/AdminMenu.tsx
@@ -14,6 +14,8 @@ import { List } from "@material-ui/icons";
 import orderBy from "lodash/orderBy";
 import PaginatedTable from "../generic/PaginatedTable";
 
+const ADMIN_TABLE_PAGE_SIZE = 15;
+
 export interface IAdminMenuProps {
     token: string;
     userId: number;
@@ -22,7 +24,8 @@ export interface IAdminMenuProps {
 export default class AdminMenu extends React.Component<IAdminMenuProps, {}> {
     state = {
         accounts: undefined,
-        searchFilter: ""
+        searchFilter: "",
+        page: 0
     };
 
     componentDidMount() {
@@ -94,14 +97,19 @@ export default class AdminMenu extends React.Component<IAdminMenuProps, {}> {
                                 onChange={this.handleSearchFilterChange}
                             />
                             <PaginatedTable
-                                totalCount={accounts.length}
+                                data={orderBy(
+                                    accounts,
+                                    a => `${a.first_n} ${a.last_n}`
+                                ).slice(
+                                    this.state.page * ADMIN_TABLE_PAGE_SIZE,
+                                    (this.state.page + 1) *
+                                        ADMIN_TABLE_PAGE_SIZE
+                                )}
+                                count={accounts.length}
+                                page={this.state.page}
+                                rowsPerPage={ADMIN_TABLE_PAGE_SIZE}
+                                onChangePage={page => this.setState({ page })}
                                 getRowKey={account => account.id}
-                                getNextN={(n: number, startingAt: number) =>
-                                    orderBy(
-                                        accounts,
-                                        a => `${a.first_n} ${a.last_n}`
-                                    ).slice(startingAt, startingAt + n)
-                                }
                                 renderRow={account => (
                                     <UserTableRow
                                         token={this.props.token}


### PR DESCRIPTION
Now, faceted search results and pagination in the file browser reflect the true contents of the `downloadable_files` table, not just a client-side pagination/filtering on the first 200 records in that table (what exists currently).

Free-text search has been temporarily removed, since there isn't an immediately easy way to do this given the way we currently handle filtering in the API, and free-text search isn't currently in any user stories.