### PR TITLE
Fix WES template download buttons in upload markdown

### DIFF
--- a/src/components/assays/AssayInstructions.tsx
+++ b/src/components/assays/AssayInstructions.tsx
@@ -54,14 +54,13 @@ const AssayInstructions: React.FunctionComponent<
                             <CopyIdToken />
                         ) : (
                             <TemplateDownloadButton
+                                fullWidth
                                 color="primary"
                                 templateName={assay}
                                 templateType="metadata"
                                 variant="contained"
                                 startIcon={<CloudDownload />}
-                            >
-                                Download an empty {assay} template
-                            </TemplateDownloadButton>
+                            />
                         )}
                     </Grid>
                 </Grid>

--- a/src/components/generic/TemplateDownloadButton.tsx
+++ b/src/components/generic/TemplateDownloadButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button } from "@material-ui/core";
+import { Button, Grid } from "@material-ui/core";
 import { ButtonProps } from "@material-ui/core/Button";
 import { InfoContext } from "../info/InfoProvider";
 
@@ -19,17 +19,31 @@ const TemplateDownloadButton: React.FunctionComponent<
 > = ({ templateName: name, templateType, ...buttonProps }) => {
     const info = React.useContext(InfoContext);
 
-    const hasURL = info && info.supportedTemplates[templateType].includes(name);
-    if (!hasURL) {
+    // For, e.g., templateName == WES, we expect multiple template types
+    // (wes_fastq and wes_bam). In that case, multiple buttons will render.
+    const types =
+        info &&
+        info.supportedTemplates[templateType].filter(typ =>
+            typ.startsWith(name)
+        );
+    if (!types) {
         return null;
     }
 
-    const templateURL = nameToURL(templateType, name);
+    const templateURLs = types.map(typ => nameToURL(templateType, typ));
 
     return (
-        <form method="get" action={templateURL}>
-            <Button type="submit" {...buttonProps} />
-        </form>
+        <Grid container direction="column" spacing={1}>
+            {templateURLs.map((url, i) => (
+                <Grid item key={url}>
+                    <form method="get" action={url}>
+                        <Button type="submit" {...buttonProps}>
+                            Download an empty {types[i]} template
+                        </Button>
+                    </form>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 


### PR DESCRIPTION
Now, if a certain assay type has multiple template types associated with it, multiple download buttons will render on the assay upload doc page.
<img width="899" alt="Screen Shot 2020-01-07 at 10 11 24 AM" src="https://user-images.githubusercontent.com/14116434/71905408-16e01280-3136-11ea-8f5e-dbd7509f8170.png">
