### PR TITLE
File filter rollback (with some style changes)

### DIFF
--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -1,17 +1,10 @@
 import * as React from "react";
-import {
-    Grid,
-    Card,
-    CardHeader,
-    Typography,
-    CardContent
-} from "@material-ui/core";
+import { Grid, Card } from "@material-ui/core";
 import uniq from "lodash/uniq";
 import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
 import { withData, IDataContext } from "../data/DataProvider";
 import { ArrayParam, useQueryParams } from "use-query-params";
 import { DataFile } from "../../model/file";
-import { FilterList } from "@material-ui/icons";
 
 export const filterConfig = {
     protocol_id: ArrayParam,
@@ -22,8 +15,12 @@ export type Filters = ReturnType<typeof useQueryParams>[0];
 
 const FileFilter: React.FunctionComponent<IDataContext> = props => {
     const [filters, setFilters] = useQueryParams(filterConfig);
-    const updateFilters = (k: keyof typeof filterConfig) => (vs: string[]) => {
-        setFilters({ [k]: vs });
+    const updateFilters = (k: keyof typeof filterConfig) => (v: string) => {
+        const currentVals = filters[k] || [];
+        const vals = currentVals.includes(v)
+            ? currentVals.filter(val => val !== v)
+            : [...currentVals, v];
+        setFilters({ [k]: vals });
     };
 
     const extractDistinct = (column: keyof DataFile) =>
@@ -34,44 +31,39 @@ const FileFilter: React.FunctionComponent<IDataContext> = props => {
 
     return (
         <Card>
-            <CardHeader
-                avatar={<FilterList />}
-                title={<Typography variant="h6">Filters</Typography>}
-            />
-            <CardContent>
-                <Grid container direction="column" spacing={2}>
-                    <Grid item xs={12}>
-                        <FileFilterCheckboxGroup
-                            title="Protocol Identifiers"
-                            config={{
-                                options: trialIds,
-                                checked: filters.protocol_id
-                            }}
-                            onChange={updateFilters("protocol_id")}
-                        />
-                    </Grid>
-                    <Grid item xs={12}>
-                        <FileFilterCheckboxGroup
-                            title="Data Categories"
-                            config={{
-                                options: types,
-                                checked: filters.type
-                            }}
-                            onChange={updateFilters("type")}
-                        />
-                    </Grid>
-                    <Grid item xs={12}>
-                        <FileFilterCheckboxGroup
-                            title="File Formats"
-                            config={{
-                                options: formats,
-                                checked: filters.data_format
-                            }}
-                            onChange={updateFilters("data_format")}
-                        />
-                    </Grid>
+            <Grid container direction="column">
+                <Grid item xs={12}>
+                    <FileFilterCheckboxGroup
+                        title="Protocol Identifiers"
+                        config={{
+                            options: trialIds,
+                            checked: filters.protocol_id
+                        }}
+                        onChange={updateFilters("protocol_id")}
+                        noTopBar
+                    />
                 </Grid>
-            </CardContent>
+                <Grid item xs={12}>
+                    <FileFilterCheckboxGroup
+                        title="Data Categories"
+                        config={{
+                            options: types,
+                            checked: filters.type
+                        }}
+                        onChange={updateFilters("type")}
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <FileFilterCheckboxGroup
+                        title="File Formats"
+                        config={{
+                            options: formats,
+                            checked: filters.data_format
+                        }}
+                        onChange={updateFilters("data_format")}
+                    />
+                </Grid>
+            </Grid>
         </Card>
     );
 };

--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -1,24 +1,36 @@
-import { makeStyles, TextField, Chip, Grid } from "@material-ui/core";
+import {
+    makeStyles,
+    FormGroup,
+    FormControlLabel,
+    Typography,
+    Divider,
+    Grid
+} from "@material-ui/core";
 import Checkbox from "@material-ui/core/Checkbox";
-import { Autocomplete } from "@material-ui/lab";
 import * as React from "react";
-import { colors } from "../../rootStyles";
+import { FilterList } from "@material-ui/icons";
 
 const useFilterStyles = makeStyles({
     header: {
-        justifyContent: "center",
-        backgroundColor: colors.DARK_BLUE_GREY,
-        color: "white",
-        minHeight: 36
+        paddingLeft: 10
+    },
+    title: {
+        fontWeight: "bold",
+        fontSize: ".8rem"
     },
     checkboxGroup: {
+        maxHeight: "10.5rem",
         flexWrap: "nowrap",
-        paddingLeft: 10,
-        maxHeight: 200,
-        overflow: "auto"
+        overflow: "auto",
+        paddingLeft: 15
+    },
+    checkboxLabel: {
+        "& .MuiFormControlLabel-label": {
+            fontSize: ".9rem"
+        }
     },
     checkbox: {
-        padding: 5
+        padding: 3
     }
 });
 
@@ -30,7 +42,8 @@ export interface IFilterConfig {
 export interface IFileFilterCheckboxGroupProps {
     title: string;
     config: IFilterConfig;
-    onChange: (options: string[]) => void;
+    noTopBar?: boolean;
+    onChange: (option: string) => void;
 }
 
 const FileFilterCheckboxGroup: React.FunctionComponent<
@@ -38,58 +51,49 @@ const FileFilterCheckboxGroup: React.FunctionComponent<
 > = props => {
     const classes = useFilterStyles();
 
-    const handleChange = (_: React.ChangeEvent<{}>, values: any) => {
-        props.onChange(values);
-    };
-
     const checked = props.config.checked || [];
 
     return (
-        <Autocomplete
-            multiple
-            autoComplete
-            disableCloseOnSelect
-            disableClearable
-            options={props.config.options}
-            value={checked}
-            onChange={handleChange}
-            renderInput={params => (
-                <TextField
-                    {...params}
-                    fullWidth
-                    variant="outlined"
-                    label={props.title}
-                    placeholder="Select multiple"
-                    InputLabelProps={{ shrink: true }}
-                />
-            )}
-            renderOption={option => (
-                <React.Fragment key={option}>
-                    <Checkbox
-                        value={option}
-                        className={classes.checkbox}
-                        checked={checked.includes(option)}
-                    ></Checkbox>
-                    {option}
-                </React.Fragment>
-            )}
-            renderTags={tags => (
-                <Grid container spacing={1}>
-                    {tags.map((tag: string) => (
-                        <Grid item key={tag}>
-                            <Chip
-                                label={tag}
-                                onDelete={() =>
-                                    props.onChange(
-                                        tags.filter((t: string) => t !== tag)
-                                    )
-                                }
-                            />
-                        </Grid>
-                    ))}
+        <>
+            {!props.noTopBar && <Divider />}
+            <Grid
+                container
+                alignItems="center"
+                wrap="nowrap"
+                className={classes.header}
+                spacing={1}
+            >
+                <Grid item>
+                    <FilterList />
                 </Grid>
-            )}
-        />
+                <Grid item>
+                    <Typography
+                        className={classes.title}
+                        variant="overline"
+                        gutterBottom
+                    >
+                        {props.title}
+                    </Typography>
+                </Grid>
+            </Grid>
+            <Divider />
+            <FormGroup className={classes.checkboxGroup} row={false}>
+                {props.config.options.map(opt => (
+                    <FormControlLabel
+                        className={classes.checkboxLabel}
+                        key={opt}
+                        label={opt}
+                        control={
+                            <Checkbox
+                                className={classes.checkbox}
+                                checked={checked.includes(opt)}
+                                onClick={() => props.onChange(opt)}
+                            />
+                        }
+                    />
+                ))}
+            </FormGroup>
+        </>
     );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 body {
     margin: 0;
     padding: 0;
+    overflow-x: hidden;
 }
 
 html *:not(code) {


### PR DESCRIPTION
The autocomplete filter in its current form provided a sub-optimal UX. This PR reverts that change, with some appearance updates.
<img width="1345" alt="Screen Shot 2020-01-21 at 3 56 19 PM" src="https://user-images.githubusercontent.com/14116434/72842584-a8876e00-3c66-11ea-818b-272fce3e7fb0.png">
