### PR TITLE
Fix filter pagination

### DIFF
--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -192,6 +192,12 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
         }
         // Track which page we're switching from.
         setPrevPage(queryPage);
+
+        // If we include prevPage in the useEffect dependencies, this
+        // effect will rerun until queryPage == prevPage, preventing
+        // the component from remaining in a state where queryPage != 0.
+        // TODO: maybe there's a refactor that prevents this issue.
+        // eslint-disable-next-line
     }, [props.token, whereClause, sortClause, queryPage, setQueryPage]);
 
     const formatObjectURL = (row: DataFile) => {

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -52,7 +52,8 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
     React.useEffect(() => setDataWillChange(false), [props.data]);
 
     const backDisabled = dataWillChange || props.page === 0;
-    const isLastPage = props.count - props.rowsPerPage * (props.page + 1) <= 0;
+    const isLastPage =
+        Math.floor(props.count / props.rowsPerPage) <= props.page;
     const nextDisabled =
         dataWillChange || props.data === undefined || isLastPage;
 

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -127,7 +127,8 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         className={classes.message}
                         color="textSecondary"
                     >
-                        {props.data === undefined
+                        {props.data === undefined ||
+                        (props.data.length === 0 && props.count > 0)
                             ? "Loading..."
                             : "No data found for these filters."}
                     </Typography>

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -128,8 +128,7 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                         className={classes.message}
                         color="textSecondary"
                     >
-                        {props.data === undefined ||
-                        (props.data.length === 0 && props.count > 0)
+                        {props.data === undefined
                             ? "Loading..."
                             : "No data found for these filters."}
                     </Typography>

--- a/src/util/usePrevious.ts
+++ b/src/util/usePrevious.ts
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function usePrevious<T>(value: T): T {
+    const ref = React.useRef<T>(value);
+
+    React.useEffect(() => {
+        ref.current = value;
+    }, [ref, value]);
+
+    return ref.current;
+}


### PR DESCRIPTION
This PR does two things:
1) sets the current file table page to 0 whenever the filter facets or table sorting are updated.
2) adds support for a `page` URL query param, so that it's possible to navigate directly to a certain page of filter results.