### PR TITLE
Fix race condition in multifile download

### DIFF
--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -82,15 +82,8 @@ export const triggerBatchDownload = async (
         fileIds.map(id => getDownloadURL(token, id))
     );
 
-    let interval: NodeJS.Timeout;
-    interval = setInterval(() => {
-        if (urls.length === 0) {
-            clearInterval(interval);
-            callback();
-        }
-        const url = urls.pop();
-        window.open(url, "_parent");
-    }, 300);
+    urls.map(url => window.open(url, "_blank"));
+    callback();
 };
 
 const BatchDownloadButton: React.FC<{

--- a/src/components/browseFiles/__tests__/FileTable.ts
+++ b/src/components/browseFiles/__tests__/FileTable.ts
@@ -55,9 +55,9 @@ test("triggerBatchDownload", async done => {
         expect(window.open).toHaveBeenCalledTimes(3);
         expect(new Set(window.open.mock.calls)).toEqual(
             new Set([
-                ["/a", "_parent"],
-                ["/b", "_parent"],
-                ["/c", "_parent"]
+                ["/a", "_blank"],
+                ["/b", "_blank"],
+                ["/c", "_blank"]
             ])
         );
         done();


### PR DESCRIPTION
Under the existing implementation, sometimes `window.open` gets called on a new URL before the previous URL has finished loading. When this happens, the file for the previous URL won't be downloaded.

This PR opens a new tab for every file being downloaded, so one file's download won't prematurely cancel another's. The resulting UX is chaotic (think: 15 tabs quickly opening then closing) and probably not what we want long term, but this solution should guarantee that all downloads complete.