### PR TITLE
Add 'show more' button instead of scroll for faceted search

### DIFF
--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -5,7 +5,8 @@ import {
     Typography,
     Divider,
     Grid,
-    Chip
+    Chip,
+    Button
 } from "@material-ui/core";
 import Checkbox from "@material-ui/core/Checkbox";
 import * as React from "react";
@@ -20,9 +21,7 @@ const useFilterStyles = makeStyles({
         fontSize: ".8rem"
     },
     checkboxGroup: {
-        maxHeight: "12.5rem",
         flexWrap: "nowrap",
-        overflow: "auto",
         paddingLeft: 15
     },
     checkboxLabel: {
@@ -32,8 +31,13 @@ const useFilterStyles = makeStyles({
     },
     checkbox: {
         padding: 3
+    },
+    showMoreButton: {
+        fontSize: ".7rem"
     }
 });
+
+const NUM_INITIAL_FILTERS = 5;
 
 export interface IFilterConfig {
     options: string[];
@@ -47,12 +51,14 @@ export interface IFileFilterCheckboxGroupProps {
     onChange: (option: string) => void;
 }
 
-const FileFilterCheckboxGroup: React.FunctionComponent<
-    IFileFilterCheckboxGroupProps
-> = props => {
+const FileFilterCheckboxGroup: React.FunctionComponent<IFileFilterCheckboxGroupProps> = props => {
     const classes = useFilterStyles();
+    const [showMore, setShowMore] = React.useState<boolean>(false);
 
     const checked = props.config.checked || [];
+    const options = showMore
+        ? props.config.options
+        : props.config.options.slice(0, NUM_INITIAL_FILTERS);
 
     return (
         <>
@@ -95,7 +101,7 @@ const FileFilterCheckboxGroup: React.FunctionComponent<
             </Grid>
             <Divider />
             <FormGroup className={classes.checkboxGroup} row={false}>
-                {props.config.options.map(opt => (
+                {options.map(opt => (
                     <FormControlLabel
                         className={classes.checkboxLabel}
                         key={opt}
@@ -110,6 +116,16 @@ const FileFilterCheckboxGroup: React.FunctionComponent<
                     />
                 ))}
             </FormGroup>
+            <Grid container justify="center">
+                <Button
+                    className={classes.showMoreButton}
+                    size="small"
+                    color="primary"
+                    onClick={() => setShowMore(!showMore)}
+                >
+                    {showMore ? "fewer options" : "more options"}
+                </Button>
+            </Grid>
         </>
     );
 };


### PR DESCRIPTION
This is more in line with typical faceted search design patterns.
<img width="311" alt="Screen Shot 2020-03-09 at 9 53 32 AM" src="https://user-images.githubusercontent.com/14116434/76219274-f5f67500-61eb-11ea-98f2-9e47bc11f559.png">
<img width="306" alt="Screen Shot 2020-03-09 at 9 53 39 AM" src="https://user-images.githubusercontent.com/14116434/76219275-f68f0b80-61eb-11ea-80a2-b0b4e10f77e1.png">

