### PR TITLE
Extend idle timeout

### DIFF
--- a/src/components/identity/AuthProvider.tsx
+++ b/src/components/identity/AuthProvider.tsx
@@ -12,7 +12,7 @@ import { IError, ErrorContext } from "../errors/ErrorGuard";
 
 const CLIENT_ID: string = process.env.REACT_APP_AUTH0_CLIENT_ID!;
 const DOMAIN: string = process.env.REACT_APP_AUTH0_DOMAIN!;
-const IDLE_TIMEOUT: number = 1000 * 60 * 15;
+const IDLE_TIMEOUT: number = 1000 * 60 * 60 * 4;
 
 export const auth0Client = new auth0.WebAuth({
     domain: DOMAIN,


### PR DESCRIPTION
Extending from 15 mins to 4 hrs (to match signature token lifetime).