### PR TITLE
Trial metadata saving error user feedback; warn users if they have unsaved changes

### DIFF
--- a/src/components/generic/Alert.tsx
+++ b/src/components/generic/Alert.tsx
@@ -13,7 +13,7 @@ export interface IAlertProps {
     description?: string;
     open?: boolean;
     onAccept: () => void;
-    onCancel: () => void;
+    onCancel?: () => void;
 }
 
 const Alert: React.FC<IAlertProps> = props => {
@@ -30,9 +30,11 @@ const Alert: React.FC<IAlertProps> = props => {
                 )}
             </DialogContent>
             <DialogActions>
-                <Button onClick={props.onCancel} color="secondary">
-                    Cancel
-                </Button>
+                {props.onCancel && (
+                    <Button onClick={props.onCancel} color="secondary">
+                        Cancel
+                    </Button>
+                )}
                 <Button onClick={props.onAccept} color="primary">
                     OK
                 </Button>

--- a/src/components/trials/steps/FormStepFooter.tsx
+++ b/src/components/trials/steps/FormStepFooter.tsx
@@ -51,7 +51,7 @@ const FormStepFooter: React.FC<ITrialFormFooterProps> = ({
                                         : goToNextStep
                                 }
                             >
-                                save and continue
+                                next
                             </Button>
                         )}
                     </Grid>


### PR DESCRIPTION
The trial management UI was not catching 422 errors from the API after trying to save invalid trial metadata. This PR now catches such errors and displays them to the user in an alert.

Also, this PR (hopefully) simplifies data saving behavior. Advancing in the form no longer saves data - only pressing the "Save Changes" button does. If the user tries to close or refresh the page without saving, the browser will warn them about losing their unsaved changes.