### PR TITLE
FormStepDataSheet performance

### DIFF
--- a/src/components/trials/steps/ParticipantsStep.tsx
+++ b/src/components/trials/steps/ParticipantsStep.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { countBy } from "lodash";
+import { countBy, omit } from "lodash";
 import { useTrialFormContext, useTrialFormSaver } from "../TrialForm";
 import { useForm, FormContext } from "react-hook-form";
 import { Grid } from "@material-ui/core";
@@ -44,7 +44,14 @@ const ParticipantsStep: React.FC = () => {
     const { trial, setHasChanged } = useTrialFormContext();
     const formInstance = useForm({ mode: "onChange" });
     const { getValues, handleSubmit } = formInstance;
-    const getParticipants = () => getValues({ nest: true });
+    const getParticipants = () => {
+        const participants = getValues({ nest: true })[KEY_NAME];
+        return {
+            [KEY_NAME]: participants.map((p: IParticipant) =>
+                !p.cohort_name ? omit(p, "cohort_name") : p
+            )
+        };
+    };
 
     useTrialFormSaver(getParticipants);
 

--- a/src/components/trials/steps/ParticipantsStep.tsx
+++ b/src/components/trials/steps/ParticipantsStep.tsx
@@ -50,7 +50,6 @@ const ParticipantsStep: React.FC = () => {
 
     const idSet = new Set<string>();
     const makeRow = (participant?: any) => {
-        console.log(makeRow, participant);
         if (participant) {
             idSet.add(participant.cidc_participant_id);
             return [


### PR DESCRIPTION
For tables with more than 50 or so cells, `FormStepDataSheet` performance was prohibitively slow. This has something to do with the underlying `ReactDataSheet` component's off-the-shelf performance limitations - every cell in the table re-renders when one cell changes. 

This PR uses `React.memo` to prevent unnecessary cell re-renders of the `RowRenderer` component when the data table state changes.
