### PR TITLE
Nested file filter facets

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=http://localhost:5000
+REACT_APP_API_URL=https://staging-api.cimac-network.org
 REACT_APP_ENV=dev

--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=https://staging-api.cimac-network.org
+REACT_APP_API_URL=http://localhost:5000
 REACT_APP_ENV=dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -14508,9 +14508,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "quantize": {
       "version": "1.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,8 +53,8 @@ export default function App() {
                     <MuiThemeProvider theme={theme}>
                         <ErrorGuard>
                             <AuthProvider>
-                                <UserProvider>
-                                    <InfoProvider>
+                                <InfoProvider>
+                                    <UserProvider>
                                         <Header />
                                         <div className={classes.content}>
                                             <Switch>
@@ -108,8 +108,8 @@ export default function App() {
                                             </Switch>
                                         </div>
                                         <Footer />
-                                    </InfoProvider>
-                                </UserProvider>
+                                    </UserProvider>
+                                </InfoProvider>
                             </AuthProvider>
                         </ErrorGuard>
                     </MuiThemeProvider>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,7 +8,7 @@ import axios, {
     CancelToken
 } from "axios";
 import Permission from "../model/permission";
-import { Dictionary } from "lodash";
+import { IFacets } from "../components/browseFiles/FileFilter";
 
 const URL: string = process.env.REACT_APP_API_URL!;
 
@@ -262,7 +262,7 @@ function revokePermission(token: string, permissionID: number): Promise<any> {
     );
 }
 
-function getFilterFacets(token: string): Promise<Dictionary<string[]>> {
+function getFilterFacets(token: string): Promise<IFacets> {
     return getApiClient(token)
         .get("downloadable_files/filter_facets")
         .then(_extractItem);

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -44,17 +44,15 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
                 toggleFilter(k, v.join(ARRAY_PARAM_DELIM));
             } else {
                 const keyFilters = filters[k] || [];
-                const facetFamily = v.slice(0, 2).join(ARRAY_PARAM_DELIM);
+                const facetFamily = [category, facet].join(ARRAY_PARAM_DELIM);
                 const facetsInFamily = facets[k][category][
                     facet
                 ].map((f: string) => [facetFamily, f].join(ARRAY_PARAM_DELIM));
-                const isInFacetFamily = (f: string) =>
-                    f.startsWith(facetFamily);
                 const hasAllFilters =
-                    keyFilters.filter(f => isInFacetFamily(f)).length ===
+                    keyFilters.filter(f => f.startsWith(facetFamily)).length ===
                     facetsInFamily.length;
                 const newFilters = hasAllFilters
-                    ? keyFilters.filter(f => !isInFacetFamily(f))
+                    ? keyFilters.filter(f => !f.startsWith(facetFamily))
                     : uniq([...keyFilters, ...facetsInFamily]);
                 setFilters({ [k]: newFilters });
             }

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -40,7 +40,7 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
 
         if (Array.isArray(v)) {
             const [category, facet, subfacet] = v;
-            if (subfacet || Array.isArray(facets[facet])) {
+            if (subfacet || Array.isArray(facets[k][category])) {
                 toggleFilter(k, v.join(ARRAY_PARAM_DELIM));
             } else {
                 const keyFilters = filters[k] || [];
@@ -111,17 +111,26 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
                                                 options,
                                                 checked
                                             }}
-                                            onChange={args =>
-                                                Array.isArray(args)
-                                                    ? updateFilters("facets")([
-                                                          facetHeader,
-                                                          ...args
-                                                      ])
-                                                    : updateFilters("facets")([
-                                                          facetHeader,
-                                                          args
-                                                      ])
-                                            }
+                                            onChange={args => {
+                                                let facetValues: string[];
+                                                if (Array.isArray(args)) {
+                                                    facetValues = args;
+                                                } else {
+                                                    const splitArgs = args.split(
+                                                        ARRAY_PARAM_DELIM
+                                                    );
+                                                    if (splitArgs.length > 1) {
+                                                        facetValues = splitArgs;
+                                                    } else {
+                                                        facetValues = [args];
+                                                    }
+                                                }
+
+                                                return updateFilters("facets")([
+                                                    facetHeader,
+                                                    ...facetValues
+                                                ]);
+                                            }}
                                         />
                                     </Grid>
                                 );

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -1,95 +1,132 @@
 import * as React from "react";
-import {
-    Grid,
-    Card,
-    FormControlLabel,
-    Switch,
-    Typography
-} from "@material-ui/core";
+import { Grid, Card, Typography, Box } from "@material-ui/core";
 import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
-import { ArrayParam, useQueryParams, BooleanParam } from "use-query-params";
+import { ArrayParam, useQueryParams, JsonParam } from "use-query-params";
 import { withIdToken } from "../identity/AuthProvider";
 import { getFilterFacets } from "../../api/api";
 import { Dictionary } from "lodash";
 
+export interface IFacets {
+    trial_ids: string[];
+    assay_types: Dictionary<string[]>;
+    clinical_types: string[];
+    sample_types: string[];
+}
+
 export const filterConfig = {
-    raw_files: BooleanParam,
-    trial_id: ArrayParam,
-    upload_type: ArrayParam
+    trial_ids: ArrayParam,
+    assay_types: JsonParam,
+    clinical_types: ArrayParam,
+    sample_types: ArrayParam
 };
 export type Filters = ReturnType<typeof useQueryParams>[0];
 
 const FileFilter: React.FunctionComponent<{ token: string }> = props => {
-    const [facets, setFacets] = React.useState<Dictionary<string[]> | null>();
+    const [facets, setFacets] = React.useState<IFacets | undefined>();
     React.useEffect(() => {
         getFilterFacets(props.token).then(setFacets);
     }, [props.token]);
 
     const [filters, setFilters] = useQueryParams(filterConfig);
-    const updateFilters = (k: keyof typeof filterConfig) => (v: string) => {
-        if (k === "raw_files") {
-            setFilters({ [k]: v === "true" || undefined });
+    const updateFilters = (k: keyof IFacets) => (
+        v: [string, string] | string
+    ) => {
+        let vals;
+        if (k === "assay_types") {
+            const currentAssayTypes = filters[k] || {};
+            if (Array.isArray(v)) {
+                const [assayType, fileType] = v;
+                const currentFileTypes: string[] =
+                    currentAssayTypes[assayType] || [];
+                vals = {
+                    ...currentAssayTypes,
+                    [assayType]: currentFileTypes.includes(fileType)
+                        ? currentFileTypes.filter(t => t !== fileType)
+                        : [...currentFileTypes, fileType]
+                };
+            } else {
+                const currentFileTypes = currentAssayTypes[v] || [];
+                const allFileTypes = facets![k][v];
+                vals =
+                    currentFileTypes.length === allFileTypes.length
+                        ? { ...currentAssayTypes, [v]: [] }
+                        : { ...currentAssayTypes, [v]: allFileTypes };
+            }
         } else {
-            const currentVals = filters[k] || [];
-            const vals = currentVals.includes(v)
+            const currentVals = (filters[k] as string[]) || ([] as string[]);
+            vals = currentVals.includes(v as string)
                 ? currentVals.filter(val => val !== v)
                 : [...currentVals, v];
-            setFilters({ [k]: vals });
         }
+        setFilters({ [k]: vals });
     };
 
+    if (!facets) {
+        return null;
+    }
+
     return (
-        <Card>
-            <Grid container direction="column">
-                <Grid item>
-                    <FormControlLabel
-                        style={{ padding: 10 }}
-                        control={
-                            <Switch
-                                size="small"
-                                color="primary"
-                                checked={!!filters.raw_files}
-                                onChange={(_, checked) =>
-                                    updateFilters("raw_files")(
-                                        checked.toString()
-                                    )
-                                }
+        <>
+            <Box marginBottom={1}>
+                <Typography color="textSecondary" variant="caption">
+                    Refine your search
+                </Typography>
+            </Box>
+            <Card>
+                <Grid container direction="column">
+                    {facets.trial_ids && (
+                        <Grid item xs={12}>
+                            <FileFilterCheckboxGroup<string[]>
+                                searchable
+                                noTopDivider
+                                title="Protocol Identifiers"
+                                config={{
+                                    options: facets.trial_ids,
+                                    checked: filters.trial_ids
+                                }}
+                                onChange={updateFilters("trial_ids")}
                             />
-                        }
-                        label={
-                            <Typography variant="body2">
-                                Include raw files in results
-                            </Typography>
-                        }
-                    />
+                        </Grid>
+                    )}
+                    {facets.assay_types && (
+                        <Grid item xs={12}>
+                            <FileFilterCheckboxGroup
+                                title="Assay Types"
+                                config={{
+                                    options: facets.assay_types,
+                                    checked: filters.assay_types
+                                }}
+                                onChange={updateFilters("assay_types")}
+                            />
+                        </Grid>
+                    )}
+                    {facets.sample_types && (
+                        <Grid item xs={12}>
+                            <FileFilterCheckboxGroup
+                                title="Sample Types"
+                                config={{
+                                    options: facets.sample_types,
+                                    checked: filters.sample_types
+                                }}
+                                onChange={updateFilters("sample_types")}
+                            />
+                        </Grid>
+                    )}
+                    {facets.clinical_types && (
+                        <Grid item xs={12}>
+                            <FileFilterCheckboxGroup
+                                title="Clinical Types"
+                                config={{
+                                    options: facets.clinical_types,
+                                    checked: filters.clinical_types
+                                }}
+                                onChange={updateFilters("clinical_types")}
+                            />
+                        </Grid>
+                    )}
                 </Grid>
-                {facets && facets.trial_id && (
-                    <Grid item xs={12}>
-                        <FileFilterCheckboxGroup
-                            searchable
-                            title="Protocol Identifiers"
-                            config={{
-                                options: facets.trial_id,
-                                checked: filters.trial_id
-                            }}
-                            onChange={updateFilters("trial_id")}
-                        />
-                    </Grid>
-                )}
-                {facets && facets.upload_type && (
-                    <Grid item xs={12}>
-                        <FileFilterCheckboxGroup
-                            title="Data Categories"
-                            config={{
-                                options: facets.upload_type,
-                                checked: filters.upload_type
-                            }}
-                            onChange={updateFilters("upload_type")}
-                        />
-                    </Grid>
-                )}
-            </Grid>
-        </Card>
+            </Card>
+        </>
     );
 };
 

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -4,7 +4,7 @@ import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
 import { ArrayParam, useQueryParams, JsonParam } from "use-query-params";
 import { withIdToken } from "../identity/AuthProvider";
 import { getFilterFacets } from "../../api/api";
-import { Dictionary } from "lodash";
+import { Dictionary, omit } from "lodash";
 
 export interface IFacets {
     trial_ids: string[];
@@ -49,7 +49,7 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
                 const allFileTypes = facets![k][v];
                 vals =
                     currentFileTypes.length === allFileTypes.length
-                        ? { ...currentAssayTypes, [v]: [] }
+                        ? omit(currentAssayTypes, v)
                         : { ...currentAssayTypes, [v]: allFileTypes };
             }
         } else {

--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -23,6 +23,7 @@ import {
 import useSearch from "../../util/useSearch";
 import { Dictionary, map, some } from "lodash";
 import { useUserContext } from "../identity/UserProvider";
+import { withStyles } from "@material-ui/styles";
 
 const searchBoxMargin = 15;
 
@@ -154,6 +155,12 @@ interface IPermsAwareCheckboxProps extends CheckboxProps {
     label?: React.ReactNode;
 }
 
+const PermsTooltip = withStyles(() => ({
+    tooltip: {
+        margin: -5
+    }
+}))(Tooltip);
+
 const PermsAwareCheckbox: React.FC<IPermsAwareCheckboxProps> = ({
     label,
     facetType,
@@ -193,9 +200,7 @@ const PermsAwareCheckbox: React.FC<IPermsAwareCheckboxProps> = ({
     return hasPermission ? (
         control
     ) : (
-        <Tooltip title="unauthorized to view" placement="right">
-            {control}
-        </Tooltip>
+        <PermsTooltip title="unauthorized to view">{control}</PermsTooltip>
     );
 };
 

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -60,9 +60,10 @@ export interface IFileTableProps {
 }
 
 export const filterParams = (filters: Filters) => {
-    const stringifyIfDefined = (v?: any) =>
-        !isEmpty(v) ? JSON.stringify(v) : undefined;
-    return mapValues(filters, stringifyIfDefined);
+    return {
+        trial_ids: filters.trial_ids?.join(","),
+        facets: filters.facets?.join(",")
+    };
 };
 
 export const sortParams = (header?: IHeader) => {

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -19,7 +19,7 @@ import { withIdToken } from "../identity/AuthProvider";
 import MuiRouterLink from "../generic/MuiRouterLink";
 import { CloudDownload } from "@material-ui/icons";
 import axios, { CancelTokenSource } from "axios";
-import { mapValues } from "lodash";
+import { mapValues, isEmpty } from "lodash";
 
 const fileQueryDefaults = {
     page_size: 15
@@ -60,7 +60,8 @@ export interface IFileTableProps {
 }
 
 export const filterParams = (filters: Filters) => {
-    const stringifyIfDefined = (v?: any) => (v ? JSON.stringify(v) : undefined);
+    const stringifyIfDefined = (v?: any) =>
+        !isEmpty(v) ? JSON.stringify(v) : undefined;
     return mapValues(filters, stringifyIfDefined);
 };
 

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -19,6 +19,7 @@ import { withIdToken } from "../identity/AuthProvider";
 import MuiRouterLink from "../generic/MuiRouterLink";
 import { CloudDownload } from "@material-ui/icons";
 import axios, { CancelTokenSource } from "axios";
+import { mapValues } from "lodash";
 
 const fileQueryDefaults = {
     page_size: 15
@@ -60,12 +61,7 @@ export interface IFileTableProps {
 
 export const filterParams = (filters: Filters) => {
     const stringifyIfDefined = (v?: any) => (v ? JSON.stringify(v) : undefined);
-    return {
-        trial_ids: stringifyIfDefined(filters.trial_ids),
-        assay_types: stringifyIfDefined(filters.assay_types),
-        sample_types: stringifyIfDefined(filters.sample_types),
-        clinical_types: stringifyIfDefined(filters.clinical_types)
-    };
+    return mapValues(filters, stringifyIfDefined);
 };
 
 export const sortParams = (header?: IHeader) => {

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -58,16 +58,17 @@ export interface IFileTableProps {
     history: any;
 }
 
-export const filterParamsFromFilters = (filters: Filters) => {
+export const filterParams = (filters: Filters) => {
+    const stringifyIfDefined = (v?: any) => (v ? JSON.stringify(v) : undefined);
     return {
-        trial_ids: filters.trial_id?.join(","),
-        upload_types: filters.upload_type?.join(","),
-        analysis_friendly:
-            filters.raw_files === undefined ? true : !filters.raw_files
+        trial_ids: stringifyIfDefined(filters.trial_ids),
+        assay_types: stringifyIfDefined(filters.assay_types),
+        sample_types: stringifyIfDefined(filters.sample_types),
+        clinical_types: stringifyIfDefined(filters.clinical_types)
     };
 };
 
-export const sortParamsFromHeader = (header?: IHeader) => {
+export const sortParams = (header?: IHeader) => {
     return (
         header && {
             sort_field: header?.key,
@@ -177,8 +178,8 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
                 props.token,
                 {
                     page_num: queryPage,
-                    ...filterParamsFromFilters(filters),
-                    ...sortParamsFromHeader(sortHeader),
+                    ...filterParams(filters),
+                    ...sortParams(sortHeader),
                     ...fileQueryDefaults
                 },
                 axiosCanceller.current.token

--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -19,7 +19,6 @@ import { withIdToken } from "../identity/AuthProvider";
 import MuiRouterLink from "../generic/MuiRouterLink";
 import { CloudDownload } from "@material-ui/icons";
 import axios, { CancelTokenSource } from "axios";
-import { mapValues, isEmpty } from "lodash";
 
 const fileQueryDefaults = {
     page_size: 15

--- a/src/components/browseFiles/__tests__/FileTable.ts
+++ b/src/components/browseFiles/__tests__/FileTable.ts
@@ -6,13 +6,11 @@ test("filterParams", () => {
     expect(filterParams({})).toEqual({});
     const exampleFilters = {
         trial_ids: ["a", "b"],
-        sample_types: undefined,
-        assay_types: { foo: ["a", "b"], bar: ["1", "2"] },
-        clinical_types: undefined
+        facets: ["foo|a|1", "foo|a|2", "bar|1", "bar|2"]
     };
     expect(filterParams(exampleFilters)).toEqual({
-        trial_ids: JSON.stringify(exampleFilters.trial_ids),
-        assay_types: JSON.stringify(exampleFilters.assay_types)
+        trial_ids: "a,b",
+        facets: "foo|a|1,foo|a|2,bar|1,bar|2"
     });
 });
 

--- a/src/components/browseFiles/__tests__/FileTable.ts
+++ b/src/components/browseFiles/__tests__/FileTable.ts
@@ -1,47 +1,27 @@
-import {
-    triggerBatchDownload,
-    filterParamsFromFilters,
-    sortParamsFromHeader
-} from "../FileTable";
+import { triggerBatchDownload, filterParams, sortParams } from "../FileTable";
 import { getDownloadURL } from "../../../api/api";
 jest.mock("../../../api/api");
 
-test("filterParamsFromFilters", () => {
-    expect(filterParamsFromFilters({})).toEqual({
-        analysis_friendly: true,
-        trial_ids: undefined,
-        upload_types: undefined
-    });
-    expect(filterParamsFromFilters({ raw_files: true })).toEqual({
-        analysis_friendly: false,
-        trial_ids: undefined,
-        upload_types: undefined
-    });
-    expect(
-        filterParamsFromFilters({ upload_type: [1, 2], raw_files: true })
-    ).toEqual({
-        analysis_friendly: false,
-        trial_ids: undefined,
-        upload_types: "1,2"
-    });
-    expect(
-        filterParamsFromFilters({
-            upload_type: [1, 2],
-            trial_id: ["a", "b"]
-        })
-    ).toEqual({
-        analysis_friendly: true,
-        trial_ids: "a,b",
-        upload_types: "1,2"
+test("filterParams", () => {
+    expect(filterParams({})).toEqual({});
+    const exampleFilters = {
+        trial_ids: ["a", "b"],
+        sample_types: undefined,
+        assay_types: { foo: ["a", "b"], bar: ["1", "2"] },
+        clinical_types: undefined
+    };
+    expect(filterParams(exampleFilters)).toEqual({
+        trial_ids: JSON.stringify(exampleFilters.trial_ids),
+        assay_types: JSON.stringify(exampleFilters.assay_types)
     });
 });
 
-test("sortParamsFromHeader", () => {
-    expect(sortParamsFromHeader({ key: "foo", direction: "asc" })).toEqual({
+test("sortParams", () => {
+    expect(sortParams({ key: "foo", direction: "asc" })).toEqual({
         sort_field: "foo",
         sort_direction: "asc"
     });
-    expect(sortParamsFromHeader({ key: "foo", direction: "desc" })).toEqual({
+    expect(sortParams({ key: "foo", direction: "desc" })).toEqual({
         sort_field: "foo",
         sort_direction: "desc"
     });


### PR DESCRIPTION
UI accompaniment for API changes in this PR: https://github.com/CIMAC-CIDC/cidc-api-gae/pull/271

This PR implements support for nested file filter facets. They look like:
<img width="310" alt="Screen Shot 2020-07-28 at 9 02 18 AM" src="https://user-images.githubusercontent.com/14116434/88668818-1c408280-d0b1-11ea-99ae-2a54254c5296.png">

When a user doesn't have permission to view facets for, e.g., an assay type, it looks like:
<img width="311" alt="Screen Shot 2020-07-28 at 9 05 40 AM" src="https://user-images.githubusercontent.com/14116434/88669159-89541800-d0b1-11ea-8dae-70d41db2b3c3.png">