### PR TITLE
Remove the filter facet chips

### DIFF
--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -4,7 +4,7 @@ import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
 import { ArrayParam, useQueryParams } from "use-query-params";
 import { withIdToken } from "../identity/AuthProvider";
 import { getFilterFacets } from "../../api/api";
-import { Dictionary, uniq, isEmpty } from "lodash";
+import { Dictionary, uniq } from "lodash";
 
 export interface IFacets {
     trial_ids: string[];

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { Grid, Card, Typography, Box } from "@material-ui/core";
+import { Grid, Card, Typography, Box, Button } from "@material-ui/core";
 import FileFilterCheckboxGroup from "./FileFilterCheckboxGroup";
 import { ArrayParam, useQueryParams } from "use-query-params";
 import { withIdToken } from "../identity/AuthProvider";
 import { getFilterFacets } from "../../api/api";
-import { Dictionary, uniq } from "lodash";
+import { Dictionary, uniq, isEmpty } from "lodash";
 
 export interface IFacets {
     trial_ids: string[];
@@ -26,6 +26,13 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
     }, [props.token]);
 
     const [filters, setFilters] = useQueryParams(filterConfig);
+    const hasFilters =
+        Object.values(filters).filter(fs => {
+            return fs && fs.length > 0;
+        }).length > 0;
+    const clearFilters = () => {
+        Object.keys(filters).forEach(k => setFilters({ [k]: undefined }));
+    };
     const toggleFilter = (k: keyof IFacets, v: string) => {
         const currentValues = filters[k] || [];
         const updatedValues = currentValues.includes(v)
@@ -68,16 +75,37 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
     return (
         <>
             <Box marginBottom={1}>
-                <Typography color="textSecondary" variant="caption">
-                    Refine your search
-                </Typography>
+                <Grid
+                    container
+                    justify="space-between"
+                    alignItems="baseline"
+                    wrap="nowrap"
+                >
+                    <Grid item>
+                        <Box margin={1}>
+                            <Typography color="textSecondary" variant="caption">
+                                Refine your search
+                            </Typography>
+                        </Box>
+                    </Grid>
+                    <Grid item>
+                        {hasFilters && (
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                onClick={() => clearFilters()}
+                            >
+                                Clear All
+                            </Button>
+                        )}
+                    </Grid>
+                </Grid>
             </Box>
             <Card>
                 <Grid container direction="column">
                     {facets.trial_ids && (
                         <Grid item xs={12}>
                             <FileFilterCheckboxGroup<string[]>
-                                searchable
                                 noTopDivider
                                 title="Protocol Identifiers"
                                 config={{

--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -5,7 +5,6 @@ import {
     Typography,
     Divider,
     Grid,
-    Chip,
     Button,
     TextField,
     Box,
@@ -21,7 +20,7 @@ import {
     KeyboardArrowUp
 } from "@material-ui/icons";
 import useSearch from "../../util/useSearch";
-import { Dictionary, map, some } from "lodash";
+import { Dictionary, some } from "lodash";
 import { useUserContext } from "../identity/UserProvider";
 import { withStyles } from "@material-ui/styles";
 
@@ -83,45 +82,25 @@ function FileFilterCheckboxGroup<T extends FacetOptions>(
     return (
         <>
             {props.noTopDivider || <Divider />}
-            <Grid container direction="column" className={classes.header}>
+            <Grid
+                className={classes.header}
+                container
+                alignItems="center"
+                wrap="nowrap"
+                spacing={1}
+            >
                 <Grid item>
-                    <Grid
-                        container
-                        alignItems="center"
-                        wrap="nowrap"
-                        spacing={1}
-                    >
-                        <Grid item>
-                            <FilterList />
-                        </Grid>
-                        <Grid item>
-                            <Typography
-                                className={classes.title}
-                                variant="overline"
-                                gutterBottom
-                            >
-                                {props.title}
-                            </Typography>
-                        </Grid>
-                    </Grid>
+                    <FilterList />
                 </Grid>
-                {Array.isArray(checked) && (
-                    <Grid item>
-                        <Grid container spacing={1}>
-                            {map(checked, checkedOpt => (
-                                <Grid item key={checkedOpt}>
-                                    <Chip
-                                        label={checkedOpt}
-                                        size="small"
-                                        onDelete={() =>
-                                            props.onChange(checkedOpt)
-                                        }
-                                    />
-                                </Grid>
-                            ))}
-                        </Grid>
-                    </Grid>
-                )}
+                <Grid item>
+                    <Typography
+                        className={classes.title}
+                        variant="overline"
+                        gutterBottom
+                    >
+                        {props.title}
+                    </Typography>
+                </Grid>
             </Grid>
             <Divider />
             {Array.isArray(props.config.options) ? (
@@ -320,9 +299,10 @@ const NestedBoxes = ({
                 const subchecked = checked.filter(check =>
                     check.startsWith(opt)
                 );
+                const hasCheckedSuboptions = subchecked.length > 0;
                 const isOpen =
-                    openOptions.filter(openOpt => openOpt.startsWith(opt))
-                        .length > 0;
+                    hasCheckedSuboptions ||
+                    openOptions.filter(o => o.startsWith(opt)).length > 0;
                 const suboptions = options[opt];
                 const isChecked = suboptions.length === subchecked.length;
 
@@ -360,10 +340,11 @@ const NestedBoxes = ({
                                 {isOpen ? (
                                     <IconButton
                                         size="small"
+                                        disabled={hasCheckedSuboptions}
                                         onClick={() => {
                                             setOpenOptions(
                                                 openOptions.filter(
-                                                    o => o !== opt
+                                                    o => !o.startsWith(opt)
                                                 )
                                             );
                                         }}


### PR DESCRIPTION
This PR removes the chips that would appear under facet section headers when a particular facet was selected, opting instead for increasing the visibility of selected facet checkboxes.

This PR also removes free text search from the "protocol identifier" facet section.