### PR TITLE
Fix facet category count plural

### DIFF
--- a/src/components/browseFiles/FileFilterCheckboxGroup.tsx
+++ b/src/components/browseFiles/FileFilterCheckboxGroup.tsx
@@ -313,7 +313,8 @@ const NestedBoxes = ({
                         <Grid item>{opt}</Grid>
                         <Grid item>
                             <Typography color="textSecondary" variant="caption">
-                                ({suboptions.length} file categories)
+                                ({suboptions.length} file categor
+                                {suboptions.length === 1 ? "y" : "ies"})
                             </Typography>
                         </Grid>
                     </Grid>


### PR DESCRIPTION
so we don't display "(1 categories)" if a facet only has one subfacet.