### PR TITLE
Add sortable file extension column to the `FileTable`

### DIFF
--- a/src/components/browseFiles/FileTable.tsx
+++ b/src/components/browseFiles/FileTable.tsx
@@ -143,6 +143,7 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
             key: "object_url",
             label: "File"
         },
+        { key: "file_ext", label: "Ext." },
         {
             key: "file_size_bytes",
             label: "Size"
@@ -282,6 +283,7 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
                                     <TableCell>
                                         {formatObjectURL(row)}
                                     </TableCell>
+                                    <TableCell>{row.file_ext}</TableCell>
                                     <TableCell>
                                         {filesize(row.file_size_bytes)}
                                     </TableCell>

--- a/src/model/file.ts
+++ b/src/model/file.ts
@@ -11,6 +11,7 @@ export interface DataFile {
     artifact_category: string;
     upload_type: string;
     data_format: string;
+    file_ext?: string;
     additional_metadata?: {
         [prop: string]: any;
     };


### PR DESCRIPTION
relies on https://github.com/CIMAC-CIDC/cidc-api-gae/pull/279