### PR TITLE
Batch downloads using 'filelist.tsv'

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -94,6 +94,19 @@ function getSingleFile(
     );
 }
 
+function getFilelist(token: string, fileIds: number[]): Promise<Blob> {
+    return getApiClient(token)
+        .get("downloadable_files/filelist", {
+            params: { file_ids: fileIds.join(",") }
+        })
+        .then(
+            ({ data }) =>
+                new Blob([data], {
+                    type: "text/tab-separated-values"
+                })
+        );
+}
+
 function getDownloadURL(
     token: string,
     fileID: string | number
@@ -310,6 +323,7 @@ export {
     getApiClient,
     getFiles,
     getSingleFile,
+    getFilelist,
     getDownloadURL,
     getAccountInfo,
     getTrials,

--- a/src/components/browseFiles/FileFilter.tsx
+++ b/src/components/browseFiles/FileFilter.tsx
@@ -97,11 +97,10 @@ const FileFilter: React.FunctionComponent<{ token: string }> = props => {
                     <Grid item>
                         {hasFilters && (
                             <Button
-                                size="small"
                                 variant="outlined"
                                 onClick={() => clearFilters()}
                             >
-                                Clear All
+                                Clear Filters
                             </Button>
                         )}
                     </Grid>

--- a/src/components/browseFiles/__tests__/FileTable.ts
+++ b/src/components/browseFiles/__tests__/FileTable.ts
@@ -24,29 +24,3 @@ test("sortParams", () => {
         sort_direction: "desc"
     });
 });
-
-test("triggerBatchDownload", async done => {
-    const testToken = "test-token";
-    const ids = [0, 1, 2];
-    const urls = ["/a", "/b", "/c"];
-    getDownloadURL.mockImplementation((token: string, fileId: number) => {
-        expect(token).toBe(testToken);
-        return Promise.resolve(urls[fileId]);
-    });
-
-    window.open = jest.fn();
-
-    // @ts-ignore
-    await triggerBatchDownload(testToken, ids, () => {
-        expect(getDownloadURL).toBeCalledTimes(3);
-        expect(window.open).toHaveBeenCalledTimes(3);
-        expect(new Set(window.open.mock.calls)).toEqual(
-            new Set([
-                ["/a", "_blank"],
-                ["/b", "_blank"],
-                ["/c", "_blank"]
-            ])
-        );
-        done();
-    });
-});

--- a/src/components/generic/PaginatedTable.tsx
+++ b/src/components/generic/PaginatedTable.tsx
@@ -9,8 +9,10 @@ import {
     TablePagination,
     Typography,
     makeStyles,
-    Box
+    Box,
+    Checkbox
 } from "@material-ui/core";
+import { intersection, union, difference } from "lodash";
 
 const useStyles = makeStyles({
     message: {
@@ -18,36 +20,63 @@ const useStyles = makeStyles({
     },
     row: {
         cursor: "auto !important"
+    },
+    checkbox: {
+        padding: 0
+    },
+    checkboxCell: {
+        paddingRight: 0
     }
 });
 
-export interface IPaginatedTableProps {
+export interface IRowWithId {
+    id: number;
+}
+
+export interface IPaginatedTableProps<T extends IRowWithId> {
     headers?: IHeader[];
-    data?: DataRow[];
+    data?: T[];
     count: number;
     page: number;
     rowsPerPage: number;
-    getRowKey: (row: DataRow) => string | number;
+    getRowKey: (row: T) => string | number;
     onChangePage: (page: number) => void;
     onClickHeader?: (header: IHeader) => void;
-    onClickRow?: (row: DataRow) => void;
-    renderRowContents?: (row: DataRow) => React.ReactElement;
+    onClickRow?: (row: T) => void;
+    renderRowContents?: (row: T) => React.ReactElement;
+    selectedRowIds?: number[];
+    setSelectedRowIds?: (rows: number[]) => void;
 }
 
 export interface IHeader {
     key: string;
-    label: string;
+    label: string | React.ReactElement;
     format?: (v: any) => string | React.ReactElement;
     active?: boolean;
     direction?: "asc" | "desc";
     disableSort?: boolean;
 }
 
-// TODO (maybe): refine this type
-export type DataRow = any;
-
-const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
+function PaginatedTable<T extends IRowWithId>(props: IPaginatedTableProps<T>) {
     const classes = useStyles();
+
+    const pageIds = props.data ? props.data.map(d => d.id) : undefined;
+    const selectedPageIds =
+        props.selectedRowIds && pageIds
+            ? intersection(props.selectedRowIds, pageIds)
+            : [];
+    const allSelected = selectedPageIds?.length === props.rowsPerPage;
+    const toggleSelectAll = () => {
+        if (props.selectedRowIds && props.setSelectedRowIds && pageIds) {
+            if (allSelected) {
+                props.setSelectedRowIds(
+                    difference(props.selectedRowIds, pageIds)
+                );
+            } else {
+                props.setSelectedRowIds(union(pageIds, props.selectedRowIds));
+            }
+        }
+    };
 
     const [dataWillChange, setDataWillChange] = React.useState<boolean>(true);
     React.useEffect(() => setDataWillChange(false), [props.data]);
@@ -64,6 +93,18 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                 {props.headers && (
                     <TableHead>
                         <TableRow className={classes.row}>
+                            {props.selectedRowIds !== undefined && (
+                                <TableCell>
+                                    {props.data && (
+                                        <Checkbox
+                                            className={classes.checkbox}
+                                            size="small"
+                                            onChange={() => toggleSelectAll()}
+                                            checked={allSelected}
+                                        />
+                                    )}
+                                </TableCell>
+                            )}
                             {props.headers.map(header => (
                                 <TableCell key={header.key}>
                                     <Box whiteSpace="nowrap">
@@ -110,6 +151,17 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
                                     props.onClickRow && props.onClickRow(row)
                                 }
                             >
+                                {props.selectedRowIds !== undefined && (
+                                    <TableCell className={classes.checkboxCell}>
+                                        <Checkbox
+                                            className={classes.checkbox}
+                                            size="small"
+                                            checked={selectedPageIds.includes(
+                                                row.id
+                                            )}
+                                        />
+                                    </TableCell>
+                                )}
                                 {props.renderRowContents
                                     ? props.renderRowContents(row)
                                     : props.headers
@@ -160,6 +212,6 @@ const PaginatedTable: React.FC<IPaginatedTableProps> = props => {
             />
         </>
     );
-};
+}
 
 export default PaginatedTable;


### PR DESCRIPTION
* more intuitive file selection logic - maintain previous selection while changing filters
* batch download via `filelist.tsv` rather than new tab popups