### PR TITLE
Simplify AuthProvider component and tests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import App from './App';
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import App from "./App";
+jest.mock("auth0-js");
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+it("renders without crashing", () => {
+    const div = document.createElement("div");
+    ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/components/identity/AuthProvider.test.tsx
+++ b/src/components/identity/AuthProvider.test.tsx
@@ -1,202 +1,124 @@
 import * as React from "react";
-import { render } from "@testing-library/react";
+import { render, cleanup, act } from "@testing-library/react";
 import AuthProvider, {
     auth0Client,
-    setSession,
-    handleAuthentication
+    IAuthData,
+    AuthContext
 } from "./AuthProvider";
-import auth0 from "auth0-js";
+import auth0, { Auth0Callback } from "auth0-js";
 import { Router } from "react-router";
 import history from "./History";
-import { Location } from "history";
 jest.mock("auth0-js");
 
 auth0.WebAuth.mockImplementation(() => ({
     authorize: jest.fn(),
     logout: jest.fn(),
-    checkSession: jest.fn(),
-    parseHash: jest.fn()
+    checkSession: jest.fn()
 }));
+
+const authResponse = {
+    idToken: "test-token",
+    idTokenPayload: {
+        email: "test@email.com",
+        given_name: "john",
+        family_name: "doe"
+    }
+};
+
+const mockSignedIn = () => {
+    auth0Client.checkSession.mockImplementation(
+        (_: any, cb: Auth0Callback<any>) => {
+            cb(null, authResponse);
+        }
+    );
+};
 
 const ChildComponent = () => <div data-testid="children" />;
 
-function renderWithChild() {
+function renderWithChild(child: React.ReactElement = <ChildComponent />) {
     return render(
         <Router history={history}>
-            <AuthProvider>
-                <ChildComponent />
-            </AuthProvider>
+            <AuthProvider>{child}</AuthProvider>
         </Router>
     );
 }
 
-beforeEach(() => {
-    localStorage.clear();
-});
-
 afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
 });
 
-it("triggers login and doesn't render the app", () => {
+it("triggers login when login is required", () => {
+    auth0Client.checkSession.mockImplementation(
+        (_: any, cb: Auth0Callback<any>) => {
+            cb({ code: "login_required" }, {});
+        }
+    );
     const { queryByTestId } = renderWithChild();
-    expect(auth0Client.authorize).toBeCalledTimes(1);
+    expect(auth0Client.checkSession).toHaveBeenCalled();
+    expect(auth0Client.authorize).toHaveBeenCalled();
     expect(queryByTestId("children")).not.toBeInTheDocument();
 });
 
-it("handles requests to '/callback' as expected", async () => {
-    const { findByTestId } = renderWithChild();
-    history.replace("/callback");
-    const callbackLoader = await findByTestId("callback-loader");
-    expect(callbackLoader).toBeInTheDocument();
-    expect(auth0Client.parseHash).toBeCalledTimes(1);
+it("silently authenticates and provides userInfo and token to children", async done => {
+    mockSignedIn();
+
+    const TestChild = (props: { expects: (authData?: IAuthData) => void }) => {
+        const authData = React.useContext(AuthContext);
+        React.useEffect(() => {
+            if (authData) {
+                props.expects(authData);
+                done();
+            }
+        }, [authData]);
+        return null;
+    };
+
+    renderWithChild(
+        <TestChild
+            expects={authData => {
+                expect(authData?.idToken).toBe(authResponse.idToken);
+                expect(authData?.user.email).toBe(
+                    authResponse.idTokenPayload.email
+                );
+                expect(authData?.user.first_n).toBe(
+                    authResponse.idTokenPayload.given_name
+                );
+                expect(authData?.user.last_n).toBe(
+                    authResponse.idTokenPayload.family_name
+                );
+            }}
+        />
+    );
 });
 
-it("handles requests to '/logout' as expected", async () => {
-    history.replace("/logout");
+it("redirects from the '/callback' route on successful login", async () => {
+    mockSignedIn();
 
-    // Set up a fake session
-    localStorage.setItem("isLoggedIn", "true");
-    localStorage.setItem("expiresAt", "99999999999");
+    // callback with no target URL
+    history.replace("/callback");
+    const r1 = renderWithChild();
+    expect(await r1.findByTestId("children")).toBeInTheDocument();
+    expect(history.location.pathname).toBe("/");
+    cleanup();
 
-    const { queryByTestId } = renderWithChild();
+    // callback with target URL
+    const returnTo = "/some/path";
+    history.replace(`/callback?returnTo=${returnTo}`);
+    const r2 = renderWithChild();
+    expect(await r2.findByTestId("children")).toBeInTheDocument();
+    expect(history.location.pathname).toBe(returnTo);
+});
 
-    const children = queryByTestId("children");
-    expect(children).not.toBeInTheDocument();
+it("calls logout when pathname is '/logout'", async () => {
+    mockSignedIn();
 
-    // Check that session was cleared
-    expect(localStorage.getItem("isLoggedIn")).toBeNull();
-    expect(localStorage.getItem("expiresAt")).toBeNull();
+    const { findByTestId } = renderWithChild();
+    await findByTestId("children");
+    expect(auth0Client.logout).toBeCalledTimes(0);
+
+    act(() => {
+        history.replace("/logout");
+    });
 
     expect(auth0Client.logout).toBeCalledTimes(1);
-    expect(auth0Client.checkSession).not.toBeCalled();
-});
-
-it("handles silent auth as expected", () => {
-    history.replace("/");
-
-    // Set up a fake session with expired token
-    localStorage.setItem("isLoggedIn", "true");
-    localStorage.setItem("expiresAt", "0");
-
-    renderWithChild();
-    // User should be logged in silently, not explicitly
-    expect(auth0Client.checkSession).toBeCalledTimes(1);
-    expect(auth0Client.authorize).toBeCalledTimes(0);
-
-    auth0Client.checkSession.mockClear();
-
-    // Set up logged-out session
-    localStorage.setItem("isLoggedIn", "false");
-
-    renderWithChild();
-    // User should be logged in explicitly, not silently
-    expect(auth0Client.checkSession).not.toBeCalled();
-    expect(auth0Client.authorize).toBeCalledTimes(1);
-});
-
-test("session setter", () => {
-    // Mock out a test sessionSetter
-    const setAuthData = jest.fn();
-    const onComplete = jest.fn();
-    const setError = jest.fn();
-    const sessionSetter = setSession(setAuthData, onComplete, setError);
-
-    const targetRoute = "/test-route";
-
-    // Well-behaved input
-    const decodedHash = {
-        idTokenPayload: {
-            email: "a",
-            given_name: "b",
-            family_name: "c",
-            exp: 1
-        },
-        idToken: "foobar"
-    };
-    sessionSetter(decodedHash, targetRoute);
-
-    const expectedUser = {
-        email: decodedHash.idTokenPayload.email,
-        first_n: decodedHash.idTokenPayload.given_name,
-        last_n: decodedHash.idTokenPayload.family_name
-    };
-    expect(setAuthData).toHaveBeenCalledWith({
-        idToken: decodedHash.idToken,
-        user: expectedUser
-    });
-    expect(history.location.pathname).toEqual(targetRoute);
-    expect(setError).not.toHaveBeenCalled();
-
-    // Reset
-    history.replace("/");
-    jest.clearAllMocks();
-
-    // Input with missing scopes
-    const decodedHashWithMissingScopes = {
-        idTokenPayload: {
-            email: "a",
-            exp: 1
-        },
-        idToken: "foobar"
-    };
-    sessionSetter(decodedHashWithMissingScopes, targetRoute);
-    expect(setError).toHaveBeenCalledWith({
-        type: "Login Error",
-        message: "userinfo missing required scope(s)"
-    });
-    expect(onComplete).not.toHaveBeenCalled();
-
-    // Reset
-    history.replace("/");
-    jest.clearAllMocks();
-
-    // Hash with missing fields
-    sessionSetter({}, targetRoute);
-    expect(setError).toHaveBeenCalledWith({
-        type: "Login Error",
-        message: "cannot set session: missing id token"
-    });
-    expect(onComplete).not.toHaveBeenCalled();
-});
-
-test("handleAuthentication", () => {
-    const sessionSetter = jest.fn();
-    const setError = jest.fn();
-    const targetRoute = "/test-route";
-
-    // Good inputs: complete auth result, and location with "next" param
-    const authResult = {
-        accessToken: "a",
-        idToken: "b"
-    };
-    auth0Client.parseHash = jest.fn((handler: any) =>
-        handler(undefined, authResult)
-    );
-    const location = { search: `?next=${targetRoute}` } as Location;
-    handleAuthentication(location, sessionSetter, setError);
-    expect(auth0Client.parseHash).toHaveBeenCalled();
-    expect(sessionSetter).toHaveBeenCalledWith(authResult, targetRoute);
-    expect(setError).not.toHaveBeenCalled();
-
-    jest.clearAllMocks();
-
-    // Missing "next" param on location
-    const locationMissingNext = { search: "" } as Location;
-    handleAuthentication(locationMissingNext, sessionSetter, setError);
-    expect(auth0Client.parseHash).toHaveBeenCalled();
-    expect(sessionSetter).toHaveBeenCalledWith(authResult, "/");
-    expect(setError).not.toHaveBeenCalled();
-
-    jest.clearAllMocks();
-
-    // Missing fields in authResult
-    auth0Client.parseHash = jest.fn((handler: any) => handler(undefined, {}));
-    handleAuthentication(location, sessionSetter, setError);
-    expect(auth0Client.parseHash).toHaveBeenCalled();
-    expect(sessionSetter).not.toHaveBeenCalled();
-    expect(setError).toHaveBeenCalledWith({
-        type: "Login Error",
-        message: "authentication failed"
-    });
 });

--- a/src/components/identity/AuthProvider.test.tsx
+++ b/src/components/identity/AuthProvider.test.tsx
@@ -96,17 +96,21 @@ it("redirects from the '/callback' route on successful login", async () => {
 
     // callback with no target URL
     history.replace("/callback");
-    const r1 = renderWithChild();
-    expect(await r1.findByTestId("children")).toBeInTheDocument();
+    await renderWithChild().findByTestId("children");
     expect(history.location.pathname).toBe("/");
     cleanup();
 
     // callback with target URL
-    const returnTo = "/some/path";
+    const returnTo = "/some/path?with=query";
     history.replace(`/callback?returnTo=${returnTo}`);
-    const r2 = renderWithChild();
-    expect(await r2.findByTestId("children")).toBeInTheDocument();
-    expect(history.location.pathname).toBe(returnTo);
+    await renderWithChild().findByTestId("children");
+    expect(history.location.pathname + history.location.search).toBe(returnTo);
+    cleanup();
+
+    // callback with bad target URL "/callback"
+    history.replace("/callback?returnTo=/callback");
+    await renderWithChild().findByTestId("children");
+    expect(history.location.pathname).toBe("/");
 });
 
 it("calls logout when pathname is '/logout'", async () => {

--- a/src/components/identity/AuthProvider.tsx
+++ b/src/components/identity/AuthProvider.tsx
@@ -76,7 +76,13 @@ const AuthProvider: React.FunctionComponent<RouteComponentProps> = props => {
 
     const targetPath = useQueryParam(TARGET_PARAM, StringParam)[0];
     const onRedirectCallback = React.useCallback(() => {
-        props.history.push(targetPath || "/");
+        // Do not redirect to targetPath that starts with "/callback",
+        // since this would lead to recursive redirection.
+        if (targetPath && !targetPath.startsWith("/callback")) {
+            props.history.push(targetPath);
+        } else {
+            props.history.push("/");
+        }
     }, [props.history]);
 
     const isAuthenticated = authData !== undefined;

--- a/src/components/identity/AuthProvider.tsx
+++ b/src/components/identity/AuthProvider.tsx
@@ -1,126 +1,36 @@
 import * as React from "react";
 import { UnregisteredAccount } from "../../model/account";
 import auth0 from "auth0-js";
-import history from "./History";
 import nanoid from "nanoid";
 import { RouteComponentProps, withRouter } from "react-router";
-import { Location } from "history";
 import IdleTimer from "react-idle-timer";
 import Loader from "../generic/Loader";
 import { Grid } from "@material-ui/core";
-import { IError, ErrorContext } from "../errors/ErrorGuard";
+import { StringParam, useQueryParam } from "use-query-params";
 
-const CLIENT_ID: string = process.env.REACT_APP_AUTH0_CLIENT_ID!;
-const DOMAIN: string = process.env.REACT_APP_AUTH0_DOMAIN!;
-const IDLE_TIMEOUT: number = 1000 * 60 * 30;
+const CLIENT_ID = process.env.REACT_APP_AUTH0_CLIENT_ID!;
+const DOMAIN = process.env.REACT_APP_AUTH0_DOMAIN!;
+const IDLE_TIMEOUT = 1000 * 60 * 30;
+const REDIRECT_URI = `${window.location.origin}/callback`;
+const TARGET_PARAM = "returnTo";
 
 export const auth0Client = new auth0.WebAuth({
     domain: DOMAIN,
     clientID: CLIENT_ID,
-    redirectUri: window.location.origin + "/callback",
+    redirectUri: REDIRECT_URI,
     responseType: "token id_token",
     scope: "openid profile email"
 });
 
-const login = () => {
+export const login = () => {
     auth0Client.authorize({
-        redirectUri:
-            window.location.origin +
-            "/callback?next=" +
-            encodeURIComponent(
-                window.location.pathname + window.location.search
-            ),
+        redirectUri: `${REDIRECT_URI}?${TARGET_PARAM}=${window.location.pathname}${window.location.search}`,
         nonce: nanoid()
     });
 };
 
-const logout = () => {
-    localStorage.removeItem("isLoggedIn");
-    localStorage.removeItem("expiresAt");
-
-    auth0Client.logout({
-        returnTo: window.location.origin
-    });
-};
-
-export const handleAuthentication = (
-    location: Location,
-    sessionSetter: (
-        authResult: auth0.Auth0DecodedHash,
-        targetRoute: string
-    ) => void,
-    setError: (error: IError) => void
-) => {
-    auth0Client.parseHash((err, authResult) => {
-        if (authResult && authResult.accessToken && authResult.idToken) {
-            const targetRoute =
-                "search" in location
-                    ? new URLSearchParams(location.search).get("next") || "/"
-                    : "/";
-            sessionSetter(authResult, targetRoute);
-        } else {
-            if (err) {
-                console.error(err);
-            }
-            setError({
-                type: "Login Error",
-                message: "authentication failed"
-            });
-        }
-    });
-};
-
-export const setSession = (
-    setAuthData: React.Dispatch<React.SetStateAction<IAuthData | undefined>>,
-    onComplete: () => void,
-    setError: (error: IError) => void
-) => (
-    { idTokenPayload: tokenInfo, idToken }: auth0.Auth0DecodedHash,
-    targetRoute: string
-) => {
-    if (idToken && tokenInfo) {
-        if (
-            !tokenInfo.email ||
-            !tokenInfo.given_name ||
-            !tokenInfo.family_name
-        ) {
-            setError({
-                type: "Login Error",
-                message: "userinfo missing required scope(s)"
-            });
-
-            return;
-        }
-
-        localStorage.setItem("isLoggedIn", "true");
-
-        const expiresAt = tokenInfo.exp * 1000;
-        localStorage.setItem("expiresAt", String(expiresAt));
-
-        const user = {
-            email: tokenInfo.email,
-            first_n: tokenInfo.given_name,
-            last_n: tokenInfo.family_name
-        };
-
-        setAuthData({
-            idToken: idToken!,
-            user
-        });
-
-        history.replace(targetRoute);
-        onComplete();
-    } else {
-        setError({
-            type: "Login Error",
-            message: "cannot set session: missing id token"
-        });
-    }
-};
-
-const isTokenExpired = () => {
-    const expiresAt = localStorage.getItem("expiresAt");
-    return expiresAt && new Date().getTime() >= parseInt(expiresAt, 10);
+export const logout = () => {
+    auth0Client.logout({ returnTo: window.location.origin });
 };
 
 export interface IAuthData {
@@ -146,88 +56,51 @@ export const AuthLoader = () => (
 );
 
 const AuthProvider: React.FunctionComponent<RouteComponentProps> = props => {
-    const setError = React.useContext(ErrorContext);
+    const [authData, setAuthData] = React.useState<IAuthData | undefined>();
 
-    const [authData, setAuthData] = React.useState<IAuthData | undefined>(
-        undefined
-    );
-    const [sessionIsSet, setSessionIsSet] = React.useState<boolean>(false);
-
-    const sessionSetter = setSession(
-        setAuthData,
-        () => setSessionIsSet(true),
-        setError
-    );
-    const tokenDidExpire = isTokenExpired();
-    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true";
-    React.useEffect(() => {
-        const isLoggingOut = props.location.pathname === "/logout";
-        if ((tokenDidExpire || !authData) && !isLoggingOut) {
-            if (isLoggedIn) {
-                auth0Client.checkSession({}, (err, authResult) => {
-                    if (
-                        authResult &&
-                        authResult.accessToken &&
-                        authResult.idToken
-                    ) {
-                        sessionSetter(
-                            authResult,
-                            props.location.pathname + props.location.search
-                        );
-                    } else {
-                        if (err) {
-                            console.error(err);
-                        }
-                        logout();
-                    }
-                });
+    const checkSession = React.useCallback(() => {
+        auth0Client.checkSession({}, (err, res) => {
+            if (err?.code === "login_required") {
+                login();
+                return;
             }
+
+            const { email, given_name, family_name } = res.idTokenPayload;
+
+            setAuthData({
+                idToken: res.idToken as string,
+                user: { email, first_n: given_name, last_n: family_name }
+            });
+        });
+    }, []);
+
+    const targetPath = useQueryParam(TARGET_PARAM, StringParam)[0];
+    const onRedirectCallback = React.useCallback(() => {
+        props.history.push(targetPath || "/");
+    }, [props.history]);
+
+    const isAuthenticated = authData !== undefined;
+    React.useEffect(() => {
+        if (props.location.pathname === "/logout") {
+            logout();
+            return;
         }
-    }, [tokenDidExpire, isLoggedIn, props.location, sessionSetter, authData]);
+        if (props.location.pathname === "/callback") {
+            onRedirectCallback();
+            return;
+        }
+        if (!isAuthenticated) {
+            checkSession();
+        }
+    }, [
+        props.location,
+        isAuthenticated,
+        props.location.pathname,
+        checkSession,
+        onRedirectCallback
+    ]);
 
-    const isCallback = props.location.pathname === "/callback";
-
-    // If the user is logged out, try to log them in, unless they
-    // are trying to access a public path
-    if (!isLoggedIn && !isCallback) {
-        login();
-        return null;
-    }
-
-    // Handle when the Auth0 authorization flow redirects to the callback endpoint
-    if (isCallback) {
-        return (
-            <div data-testid="callback-loader">
-                <AuthCallback
-                    onLoad={() =>
-                        handleAuthentication(
-                            props.location,
-                            sessionSetter,
-                            setError
-                        )
-                    }
-                />
-            </div>
-        );
-    }
-
-    // Log the user out
-    if (props.location.pathname === "/logout") {
-        logout();
-        return null;
-    }
-
-    // Session setup still in progress
-    if (!sessionIsSet) {
-        return (
-            <div data-testid="session-loader">
-                <AuthLoader data-testid="session-loader" />
-            </div>
-        );
-    }
-
-    // The user is authenticated, so render the app
-    return (
+    return isAuthenticated ? (
         <AuthContext.Provider value={authData}>
             <IdleTimer
                 ref={() => null}
@@ -236,6 +109,10 @@ const AuthProvider: React.FunctionComponent<RouteComponentProps> = props => {
             />
             {props.children}
         </AuthContext.Provider>
+    ) : (
+        <div data-testid="session-loader">
+            <AuthLoader data-testid="session-loader" />
+        </div>
     );
 };
 
@@ -249,11 +126,4 @@ export function withIdToken<P>(
 
         return <Component {...props} token={authData && authData.idToken} />;
     };
-}
-
-function AuthCallback(props: { onLoad: () => void }) {
-    const onLoad = React.useCallback(props.onLoad, []);
-    React.useEffect(onLoad, []);
-
-    return <AuthLoader />;
 }

--- a/src/components/identity/AuthProvider.tsx
+++ b/src/components/identity/AuthProvider.tsx
@@ -83,7 +83,7 @@ const AuthProvider: React.FunctionComponent<RouteComponentProps> = props => {
         } else {
             props.history.push("/");
         }
-    }, [props.history]);
+    }, [props.history, targetPath]);
 
     const isAuthenticated = authData !== undefined;
     React.useEffect(() => {


### PR DESCRIPTION
Previously, the `AuthProvider` component was doing a bunch of unnecessary, hand-rolled, error-prone stuff to track whether a user was logged in or not (using `localStorage` etc.), even though the `auth0-js` module already provides functionality that does just that via the `WebAuth.checkSession` method. This PR simplifies the authentication flow in the `AuthProvider` component by relying more heavily on `auth0-js`'s built-in session checking functionality.