### PR TITLE
Fix /callback redirect regression

### DIFF
--- a/src/components/identity/AuthProvider.tsx
+++ b/src/components/identity/AuthProvider.tsx
@@ -23,8 +23,11 @@ export const auth0Client = new auth0.WebAuth({
 });
 
 export const login = () => {
+    const returnToURL = encodeURIComponent(
+        `${window.location.pathname}${window.location.search}`
+    );
     auth0Client.authorize({
-        redirectUri: `${REDIRECT_URI}?${TARGET_PARAM}=${window.location.pathname}${window.location.search}`,
+        redirectUri: `${REDIRECT_URI}?${TARGET_PARAM}=${returnToURL}`,
         nonce: nanoid()
     });
 };


### PR DESCRIPTION
...and add tests to help prevent a similar regression during some future refactor.

(#272 broke redirection-after-login for URLs with multi-parameter query strings)