### PR TITLE
Fix /register page redirection on API error

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -112,7 +112,7 @@ function getDownloadURL(
         .then(_extractItem);
 }
 
-function getAccountInfo(token: string): Promise<Account | undefined> {
+function getAccountInfo(token: string): Promise<Account> {
     return getApiClient(token)
         .get("users/self")
         .then(_extractItem);

--- a/src/components/identity/UserProvider.test.tsx
+++ b/src/components/identity/UserProvider.test.tsx
@@ -55,9 +55,7 @@ it("handles an approved user", async () => {
 });
 
 it("handles unapproved users", async () => {
-    getAccountInfo.mockImplementation(() => {
-        return Promise.resolve({ id: 1 });
-    });
+    getAccountInfo.mockResolvedValue({ id: 1 });
 
     const { findByTestId } = renderUserProvider(true);
     await findByTestId("children");
@@ -65,8 +63,8 @@ it("handles unapproved users", async () => {
 });
 
 it("handles unregistered users", async () => {
-    getAccountInfo.mockImplementation(() => {
-        return Promise.resolve(undefined);
+    getAccountInfo.mockRejectedValue({
+        response: { data: { _error: { message: "is not registered." } } }
     });
 
     const { findByTestId } = renderUserProvider(true);
@@ -75,19 +73,13 @@ it("handles unregistered users", async () => {
 });
 
 it("handles endpoint errors", async () => {
-    getAccountInfo.mockImplementation(() => {
-        return Promise.reject({});
-    });
+    getAccountInfo.mockRejectedValue({ some: "other error" });
     const { findByTestId: fbti1, queryByText } = renderUserProvider(true);
     await fbti1("children");
-    expect(
-        queryByText(/could not load user account info/i)
-    ).toBeInTheDocument();
+    expect(queryByText(/error loading account info/i)).toBeInTheDocument();
     cleanup();
 
-    getAccountInfo.mockImplementation(() => {
-        return Promise.reject({ response: { data: "Not Found" } });
-    });
+    getAccountInfo.mockRejectedValue({ response: { data: "Not Found" } });
     const { findByTestId: fbti2 } = renderUserProvider(true);
     await fbti2("children");
     expect(history.location.pathname).toBe("/register");
@@ -95,11 +87,7 @@ it("handles endpoint errors", async () => {
 
 it("handles a disabled user", async () => {
     const user = { id: 1, approval_date: Date.now(), disabled: true };
-    getAccountInfo.mockImplementation((token: string) => {
-        expect(token).toBe(TOKEN);
-
-        return Promise.resolve(user);
-    });
+    getAccountInfo.mockResolvedValue(user);
 
     const { findByTestId } = renderUserProvider(true);
     const error = await findByTestId("error-message");
@@ -124,8 +112,10 @@ it("enables the correct tabs for each role", async () => {
         );
     };
     const mockWithRole = (role: string) => {
-        getAccountInfo.mockImplementation(() => {
-            return Promise.resolve({ id: 1, role, approval_date: Date.now() });
+        getAccountInfo.mockResolvedValue({
+            id: 1,
+            role,
+            approval_date: Date.now()
         });
     };
 

--- a/src/components/identity/UserProvider.tsx
+++ b/src/components/identity/UserProvider.tsx
@@ -41,23 +41,21 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
                 getAccountInfo(idToken)
                     .then(userAccount => {
                         setUser(userAccount);
-                        if (userAccount) {
-                            if (!userAccount.approval_date) {
-                                history.replace("/unactivated");
-                            }
-                        } else {
-                            history.replace("/register");
+                        if (!userAccount.approval_date) {
+                            history.replace("/unactivated");
                         }
                     })
                     .catch(error => {
-                        if (error.response === undefined) {
+                        const message = error.response?.data?._error?.message;
+                        // If the user isn't registered, send them to the registration page.
+                        // Otherwise, give up and display an error.
+                        if (message?.includes("not registered")) {
+                            history.replace("/register");
+                        } else {
                             setError({
                                 type: "Request Error",
-                                message:
-                                    "could not load user account information"
+                                message: "error loading account information"
                             });
-                        } else {
-                            history.replace("/register");
                         }
                     });
             } else if (!permissions && user.role) {
@@ -83,19 +81,14 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
     }, [idToken, setError, user, permissions]);
 
     const showAssays =
-        user &&
-        user.role &&
+        user?.role &&
         ["cimac-biofx-user", "cidc-biofx-user", "cidc-admin"].includes(
             user.role
         );
     const showManifests =
-        user &&
-        user.role &&
-        ["nci-biobank-user", "cidc-admin"].includes(user.role);
+        user?.role && ["nci-biobank-user", "cidc-admin"].includes(user.role);
     const showAnalyses =
-        user &&
-        user.role &&
-        ["cidc-biofx-user", "cidc-admin"].includes(user.role);
+        user?.role && ["cidc-biofx-user", "cidc-admin"].includes(user.role);
 
     const value = user && {
         ...user,
@@ -104,7 +97,6 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
         showManifests,
         showAnalyses
     };
-
     return (
         <UserContext.Provider value={value}>
             {props.children}


### PR DESCRIPTION
For no good reason, the `UserProvider` would redirect to the `/register` page after *any* error response from the API while trying to get the current user's account record. This PR updates the `UserProvider` to redirect to `/register` only if the API explicitly states that the user is unregistered; otherwise, it displays a generic error message.