### PR TITLE
Add a list of links to related files to the file details page

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=http://localhost:5000
+REACT_APP_API_URL=https://staging-api.cimac-network.org
 REACT_APP_ENV=dev

--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=https://staging-api.cimac-network.org
+REACT_APP_API_URL=http://localhost:5000
 REACT_APP_ENV=dev

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -88,6 +88,12 @@ function getSingleFile(
     return _getItem<DataFile>(token, "downloadable_files", itemID);
 }
 
+function getRelatedFiles(token: string, fileId: number): Promise<DataFile[]> {
+    return getApiClient(token)
+        .get(`downloadable_files/${fileId}/related_files`)
+        .then(_extractItems);
+}
+
 function getFilelist(token: string, fileIds: number[]): Promise<Blob> {
     return getApiClient(token)
         .get("downloadable_files/filelist", {
@@ -307,6 +313,7 @@ export {
     getApiClient,
     getFiles,
     getSingleFile,
+    getRelatedFiles,
     getFilelist,
     getDownloadURL,
     getAccountInfo,

--- a/src/components/browse-data/files/FileDetailsPage.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.tsx
@@ -14,8 +14,7 @@ import {
     Table,
     TableBody,
     TableRow,
-    TableCell,
-    Box
+    TableCell
 } from "@material-ui/core";
 import { AuthContext } from "../../identity/AuthProvider";
 import { DataFile } from "../../../model/file";
@@ -25,7 +24,6 @@ import {
     CloudDownload,
     CloudUpload,
     Link,
-    OpenInNew,
     Save
 } from "@material-ui/icons";
 import CopyToClipboardButton from "../../generic/CopyToClipboardButton";

--- a/src/components/browse-data/files/FileTable.tsx
+++ b/src/components/browse-data/files/FileTable.tsx
@@ -16,7 +16,11 @@ import MuiRouterLink from "../../generic/MuiRouterLink";
 import axios, { CancelTokenSource } from "axios";
 import { IFilters, useFilterFacets } from "../shared/FilterProvider";
 import BatchDownloadDialog from "../shared/BatchDownloadDialog";
-import { formatDate, formatFileSize } from "../../../util/formatters";
+import {
+    formatDataCategory,
+    formatDate,
+    formatFileSize
+} from "../../../util/formatters";
 
 const fileQueryDefaults = {
     page_size: 15
@@ -279,7 +283,11 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
                                     </TableCell>
                                     <TableCell>{row.trial_id}</TableCell>
                                     <TableCell>{row.file_ext}</TableCell>
-                                    <TableCell>{row.data_category}</TableCell>
+                                    <TableCell>
+                                        {formatDataCategory(
+                                            row.data_category || ""
+                                        )}
+                                    </TableCell>
                                     <TableCell>
                                         {formatFileSize(row.file_size_bytes)}
                                     </TableCell>

--- a/src/model/file.ts
+++ b/src/model/file.ts
@@ -12,6 +12,7 @@ export interface DataFile {
     upload_type: string;
     file_ext?: string;
     data_category?: string;
+    data_category_prefix?: string;
     additional_metadata?: {
         [prop: string]: any;
     };

--- a/src/util/formatters.test.ts
+++ b/src/util/formatters.test.ts
@@ -1,0 +1,8 @@
+import { formatDataCategory } from "./formatters";
+
+test("formatDataCategory", () => {
+    expect(formatDataCategory("Foo|Bar")).toBe("Foo Bar");
+    expect(formatDataCategory("Foo|")).toBe("Foo");
+    expect(formatDataCategory("Foo")).toBe("Foo");
+    expect(formatDataCategory("")).toBe("");
+});

--- a/src/util/formatters.ts
+++ b/src/util/formatters.ts
@@ -10,5 +10,8 @@ export const formatFileSize = (bytes: number) => {
 };
 
 export const formatDataCategory = (dataCategory: string) => {
-    return dataCategory.split("|").join(" ");
+    return dataCategory
+        .split("|")
+        .join(" ")
+        .trim();
 };

--- a/src/util/formatters.ts
+++ b/src/util/formatters.ts
@@ -8,3 +8,7 @@ export const formatDate = (dateStr: string) => {
 export const formatFileSize = (bytes: number) => {
     return filesize(bytes);
 };
+
+export const formatDataCategory = (dataCategory: string) => {
+    return dataCategory.split("|").join(" ");
+};


### PR DESCRIPTION
UI counterpart to https://github.com/CIMAC-CIDC/cidc-api-gae/pull/309

This PR also introduces a `formatDataCategory` helper function for displaying file data categories to the user. I thought it was going to be useful in the `RelatedFiles` component, but that didn't end up being the case. It's still useful, though, so I'm including it here.

Looks like this:
<img width="1066" alt="Screen Shot 2020-10-08 at 10 11 15 AM" src="https://user-images.githubusercontent.com/14116434/95505731-db9c9980-097c-11eb-9cd5-714e006dbfa5.png">
Or this, if no related files are found:
<img width="1071" alt="Screen Shot 2020-10-08 at 3 43 10 PM" src="https://user-images.githubusercontent.com/14116434/95505815-fc64ef00-097c-11eb-8572-fa0e4de1a81d.png">
