### PR TITLE
Full-width documentation pages

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,8 @@
-# Prod config
-# REACT_APP_AUTH0_DOMAIN=cidc.auth0.com
-# REACT_APP_AUTH0_CLIENT_ID=nI74q5VDJ2w2OaKgoK3lAkuxWvCkKP30
-# REACT_APP_API_URL=https://api.cimac-network.org/
-
 # Staging config
+#
+# Note: the contents of this file must be copied to .env for
+# the app to receive this config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
 REACT_APP_API_URL=https://staging-api.cimac-network.org
-REACT_APP_ENV=dev
+REACT_APP_ENV=staging

--- a/.env
+++ b/.env
@@ -1,8 +1,10 @@
+# Prod config
+# REACT_APP_AUTH0_DOMAIN=cidc.auth0.com
+# REACT_APP_AUTH0_CLIENT_ID=nI74q5VDJ2w2OaKgoK3lAkuxWvCkKP30
+# REACT_APP_API_URL=https://api.cimac-network.org/
+
 # Staging config
-#
-# Note: the contents of this file must be copied to .env for
-# the app to receive this config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
 REACT_APP_API_URL=https://staging-api.cimac-network.org
-REACT_APP_ENV=staging
+REACT_APP_ENV=dev

--- a/src/components/browse-data/BrowseDataPage.tsx
+++ b/src/components/browse-data/BrowseDataPage.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Grid, makeStyles } from "@material-ui/core";
+import { Button, ButtonGroup } from "@material-ui/core";
 import * as React from "react";
 import Filters from "./shared/Filters";
 import FileTable from "./files/FileTable";
@@ -6,20 +6,9 @@ import { RouteComponentProps } from "react-router";
 import TrialTable from "./trials/TrialTable";
 import FilterProvider from "./shared/FilterProvider";
 import { BooleanParam, useQueryParam } from "use-query-params";
-import { useRootStyles } from "../../rootStyles";
-
-const filterWidth = 300;
-const useStyles = makeStyles({
-    filters: { width: filterWidth, paddingRight: "1em" },
-    data: {
-        width: `calc(100% - ${filterWidth}px)`
-    }
-});
+import PageWithSidebar from "../generic/PageWithSidebar";
 
 const BrowseDataPage: React.FC<RouteComponentProps> = props => {
-    const rootClasses = useRootStyles();
-    const classes = useStyles();
-
     const [showFileView, setShowFileView] = useQueryParam(
         "file_view",
         BooleanParam
@@ -44,26 +33,16 @@ const BrowseDataPage: React.FC<RouteComponentProps> = props => {
 
     return (
         <FilterProvider trialView={!showFileView}>
-            <Grid
-                className={rootClasses.centeredPage}
-                container
-                justify="space-between"
-                wrap="nowrap"
-            >
-                <Grid item className={classes.filters}>
-                    <Filters />
-                </Grid>
-                <Grid item className={classes.data}>
-                    {showFileView ? (
-                        <FileTable
-                            history={props.history}
-                            viewToggleButton={viewToggleButton}
-                        />
-                    ) : (
-                        <TrialTable viewToggleButton={viewToggleButton} />
-                    )}
-                </Grid>
-            </Grid>
+            <PageWithSidebar sidebar={<Filters />}>
+                {showFileView ? (
+                    <FileTable
+                        history={props.history}
+                        viewToggleButton={viewToggleButton}
+                    />
+                ) : (
+                    <TrialTable viewToggleButton={viewToggleButton} />
+                )}
+            </PageWithSidebar>
         </FilterProvider>
     );
 };

--- a/src/components/generic/CIDCGithubMarkdown.tsx
+++ b/src/components/generic/CIDCGithubMarkdown.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import ReactMarkdown from "react-markdown";
 import "github-markdown-css/github-markdown.css";
 import { AuthContext } from "../identity/AuthProvider";
-import { useRootStyles } from "../../rootStyles";
 import axios from "axios";
 
 export interface ICIDCGithubMarkdownProps {
@@ -14,8 +13,6 @@ export interface ICIDCGithubMarkdownProps {
 const MARKDOWN_BASE_URL = "https://raw.githubusercontent.com/CIMAC-CIDC/";
 
 const CIDCGithubMarkdown: React.FunctionComponent<ICIDCGithubMarkdownProps> = props => {
-    const { markdown: markdownClass } = useRootStyles();
-
     const authData = React.useContext(AuthContext);
 
     const [markdown, setMarkdown] = React.useState<string | undefined>(
@@ -52,13 +49,8 @@ const CIDCGithubMarkdown: React.FunctionComponent<ICIDCGithubMarkdownProps> = pr
     }, [fullURL, idToken, props.trimLeadingHeader]);
 
     return markdown ? (
-        <ReactMarkdown
-            source={markdown}
-            className={`markdown-body ${markdownClass}`}
-        />
-    ) : (
-        <div className={markdownClass}></div>
-    );
+        <ReactMarkdown source={markdown} className="markdown-body" />
+    ) : null;
 };
 
 export default CIDCGithubMarkdown;

--- a/src/components/generic/PageWithSidebar.tsx
+++ b/src/components/generic/PageWithSidebar.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Grid, makeStyles } from "@material-ui/core";
+import { useRootStyles } from "../../rootStyles";
+
+const sidebarWidth = 300;
+const useStyles = makeStyles({
+    sidebar: { width: sidebarWidth, paddingRight: "1em" },
+    main: {
+        width: `calc(100% - ${sidebarWidth}px)`
+    }
+});
+
+export interface IPageWithSidebarProps {
+    sidebar: React.ReactElement;
+}
+
+const PageWithSidebar: React.FC<IPageWithSidebarProps> = ({
+    sidebar,
+    children
+}) => {
+    const rootClasses = useRootStyles();
+    const classes = useStyles();
+
+    return (
+        <Grid
+            className={rootClasses.centeredPage}
+            container
+            justify="space-between"
+            wrap="nowrap"
+        >
+            <Grid item className={classes.sidebar}>
+                {sidebar}
+            </Grid>
+            <Grid item className={classes.main}>
+                {children}
+            </Grid>
+        </Grid>
+    );
+};
+
+export default PageWithSidebar;

--- a/src/components/generic/TemplateDownloadButton.tsx
+++ b/src/components/generic/TemplateDownloadButton.tsx
@@ -47,9 +47,7 @@ const TemplateDownloadButton: React.FunctionComponent<ITemplateDownloadButtonPro
                 <Grid item key={url}>
                     <form method="get" action={url}>
                         <Button type="submit" {...buttonProps}>
-                            {verboseLabel
-                                ? `Download an empty ${types[i]} template`
-                                : types[i]}
+                            {verboseLabel ? `${types[i]} template` : types[i]}
                         </Button>
                     </form>
                 </Grid>

--- a/src/components/pipelines/PipelinesPage.tsx
+++ b/src/components/pipelines/PipelinesPage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useRootStyles } from "../../rootStyles";
 import {
     Grid,
     List,
@@ -15,6 +14,7 @@ import {
     Redirect
 } from "react-router-dom";
 import CIDCGithubMarkdown from "../generic/CIDCGithubMarkdown";
+import PageWithSidebar from "../generic/PageWithSidebar";
 
 const pipelineMarkdowns = {
     wes: (
@@ -61,54 +61,54 @@ const PipelinesPage: React.FC<RouteComponentProps> = props => {
         </ListItem>
     );
 
-    const classes = useRootStyles();
     return (
-        <div className={classes.centeredPage}>
-            <Grid container justify="center" direction="row" wrap="nowrap">
-                <Grid item style={{ width: 200 }}>
-                    <List style={{ paddingTop: 0 }}>
-                        <ListSubheader disableSticky>
-                            Pipeline Docs
-                        </ListSubheader>
-                        <DocsListItem
-                            label={"RIMA (RNA-seq IMmune Analysis)"}
-                            path={`/pipelines/rna`}
-                        />
-                        <DocsListItem
-                            label={"WES (Whole Exome Sequencing"}
-                            path={`/pipelines/wes`}
-                        />
-                        <DocsListItem
-                            label={"TCR (T-cell Receptor Repertoire Analysis)"}
-                            path={`/pipelines/tcr`}
-                        />
-                        <DocsListItem
-                            label={"CHIPS ATAC-seq Analysis"}
-                            path={`/pipelines/chips`}
-                        />
-                    </List>
+        <PageWithSidebar
+            sidebar={
+                <Grid container>
+                    <Grid item xs={11}>
+                        <List style={{ paddingTop: 0 }}>
+                            <ListSubheader disableSticky>
+                                Pipeline Docs
+                            </ListSubheader>
+                            <DocsListItem
+                                label={"RIMA (RNA-seq IMmune Analysis)"}
+                                path={`/pipelines/rna`}
+                            />
+                            <DocsListItem
+                                label={"WES (Whole Exome Sequencing"}
+                                path={`/pipelines/wes`}
+                            />
+                            <DocsListItem
+                                label={
+                                    "TCR (T-cell Receptor Repertoire Analysis)"
+                                }
+                                path={`/pipelines/tcr`}
+                            />
+                            <DocsListItem
+                                label={"CHIPS ATAC-seq Analysis"}
+                                path={`/pipelines/chips`}
+                            />
+                        </List>
+                    </Grid>
+                    <Grid item>
+                        <Divider orientation="vertical" />
+                    </Grid>
                 </Grid>
-                <Grid item>
-                    <Divider orientation="vertical" />
-                </Grid>
-                <Grid item>
-                    <div style={{ padding: "1em" }}>
-                        <Route
-                            path={`/pipelines/:docPath`}
-                            render={({ match }) =>
-                                pipelineMarkdowns[match.params.docPath] ||
-                                pipelineMarkdowns.rna
-                            }
-                        />
-                        <Route
-                            path="/pipelines"
-                            exact
-                            render={() => <Redirect to="pipelines/rna" />}
-                        />
-                    </div>
-                </Grid>
-            </Grid>
-        </div>
+            }
+        >
+            <Route
+                path={`/pipelines/:docPath`}
+                render={({ match }) =>
+                    pipelineMarkdowns[match.params.docPath] ||
+                    pipelineMarkdowns.rna
+                }
+            />
+            <Route
+                path="/pipelines"
+                exact
+                render={() => <Redirect to="pipelines/rna" />}
+            />
+        </PageWithSidebar>
     );
 };
 

--- a/src/components/upload-docs/UploadDocsPages.tsx
+++ b/src/components/upload-docs/UploadDocsPages.tsx
@@ -10,8 +10,8 @@ import {
 import { map } from "lodash";
 import { RouteComponentProps, Route, withRouter, Redirect } from "react-router";
 import UploadInstructions from "./UploadInstructions";
-import { useRootStyles } from "../../rootStyles";
 import { Dictionary } from "lodash";
+import PageWithSidebar from "../generic/PageWithSidebar";
 
 interface IDocPathConfig {
     path: string;
@@ -83,8 +83,6 @@ export interface IUploadDocsPageProps extends RouteComponentProps {
 }
 
 const UploadDocsPage: React.FunctionComponent<IUploadDocsPageProps> = props => {
-    const classes = useRootStyles();
-
     const DocsListItem: React.FunctionComponent<{
         label: string;
         path: string;
@@ -106,7 +104,7 @@ const UploadDocsPage: React.FunctionComponent<IUploadDocsPageProps> = props => {
         return (
             <UploadInstructions
                 docPath={`${CLIInstructionsPath}.md`}
-                title={"The CLI Command-Line Interface"}
+                title={"The CIDC Command-Line Interface"}
                 tokenButton={true}
                 uploadType={props.uploadType}
             />
@@ -137,55 +135,54 @@ const UploadDocsPage: React.FunctionComponent<IUploadDocsPageProps> = props => {
     };
 
     return (
-        <div className={classes.centeredPage}>
-            <Grid container justify="center" direction="row" wrap="nowrap">
-                <Grid item style={{ width: 200 }}>
-                    <List style={{ paddingTop: 0 }}>
-                        <ListSubheader disableSticky>
-                            General Overview
-                        </ListSubheader>
-                        <DocsListItem
-                            label={"CLI Instructions"}
-                            path={CLIInstructionsSitePath}
-                        />
-                        <ListSubheader disableSticky>
-                            Assay-Specific Docs
-                        </ListSubheader>
-                        {map(pathConfigs, (config, path) => {
-                            return (
-                                config[props.uploadType] && (
-                                    <DocsListItem
-                                        key={path}
-                                        label={config.label}
-                                        path={`/${props.uploadType}/${config.path}`}
-                                    />
-                                )
-                            );
-                        })}
-                    </List>
+        <PageWithSidebar
+            sidebar={
+                <Grid container>
+                    <Grid item xs={11}>
+                        <List>
+                            <ListSubheader disableSticky>
+                                General Overview
+                            </ListSubheader>
+                            <DocsListItem
+                                label={"CLI Instructions"}
+                                path={CLIInstructionsSitePath}
+                            />
+                            <ListSubheader disableSticky>
+                                Assay-Specific Docs
+                            </ListSubheader>
+                            {map(pathConfigs, (config, path) => {
+                                return (
+                                    config[props.uploadType] && (
+                                        <DocsListItem
+                                            key={path}
+                                            label={config.label}
+                                            path={`/${props.uploadType}/${config.path}`}
+                                        />
+                                    )
+                                );
+                            })}
+                        </List>
+                    </Grid>
+                    <Grid item>
+                        <Divider orientation="vertical" />
+                    </Grid>
                 </Grid>
-                <Grid item>
-                    <Divider orientation="vertical" />
-                </Grid>
-                <Grid item>
-                    <div style={{ padding: "1em" }}>
-                        <Route
-                            path={`/${props.uploadType}`}
-                            component={CLIRedirect}
-                            exact
-                        />
-                        <Route
-                            path={CLIInstructionsSitePath}
-                            component={CLIUploadInstructions}
-                        />
-                        <Route
-                            path={`/${props.uploadType}/:docPath`}
-                            component={SelectedUploadInstructions}
-                        />
-                    </div>
-                </Grid>
-            </Grid>
-        </div>
+            }
+        >
+            <Route
+                path={`/${props.uploadType}`}
+                component={CLIRedirect}
+                exact
+            />
+            <Route
+                path={CLIInstructionsSitePath}
+                component={CLIUploadInstructions}
+            />
+            <Route
+                path={`/${props.uploadType}/:docPath`}
+                component={SelectedUploadInstructions}
+            />
+        </PageWithSidebar>
     );
 };
 

--- a/src/components/upload-docs/UploadInstructions.tsx
+++ b/src/components/upload-docs/UploadInstructions.tsx
@@ -2,10 +2,9 @@ import * as React from "react";
 import CIDCGithubMarkdown from "../generic/CIDCGithubMarkdown";
 import TemplateDownloadButton from "../generic/TemplateDownloadButton";
 import { withIdToken, AuthContext } from "../identity/AuthProvider";
-import { Grid, Typography, Divider } from "@material-ui/core";
+import { Grid, Typography, Divider, Box } from "@material-ui/core";
 import { CloudDownload, Fingerprint } from "@material-ui/icons";
 import CopyToClipboardButton from "../generic/CopyToClipboardButton";
-import { widths } from "../../rootStyles";
 import { IUploadDocsPageProps } from "./UploadDocsPages";
 
 export interface IUploadInstructionsProps {
@@ -21,9 +20,10 @@ const CopyIdToken: React.FunctionComponent = () => {
 
     return (
         <CopyToClipboardButton
+            disableElevation
             title="Identity Token"
             copyValue={authData ? authData.idToken : ""}
-            variant="contained"
+            variant="outlined"
             color="primary"
             startIcon={<Fingerprint />}
             disabled={!authData}
@@ -37,47 +37,39 @@ const UploadInstructions: React.FunctionComponent<IUploadInstructionsProps> = pr
     const name = pathParts[pathParts.length - 1].slice(0, -3);
 
     return (
-        <Grid container direction="column">
-            <Grid item>
-                <Grid
-                    container
-                    direction="row"
-                    justify="space-between"
-                    alignItems="center"
-                    style={{ width: widths.markdownWidth }}
-                    wrap="nowrap"
-                >
-                    <Grid item>
-                        <Typography variant="h4">{props.title}</Typography>
-                    </Grid>
-                    <Grid item>
-                        {props.tokenButton ? (
-                            <CopyIdToken />
-                        ) : (
-                            <TemplateDownloadButton
-                                fullWidth
-                                verboseLabel
-                                color="primary"
-                                templateName={name}
-                                templateType={props.uploadType}
-                                variant="contained"
-                                startIcon={<CloudDownload />}
-                            />
-                        )}
-                    </Grid>
+        <>
+            <Grid
+                container
+                direction="row"
+                justify="space-between"
+                alignItems="center"
+                wrap="nowrap"
+            >
+                <Grid item xs={8}>
+                    <Typography variant="h4">{props.title}</Typography>
+                </Grid>
+                <Grid item>
+                    {props.tokenButton ? (
+                        <CopyIdToken />
+                    ) : (
+                        <TemplateDownloadButton
+                            verboseLabel
+                            fullWidth
+                            disableElevation
+                            color="primary"
+                            templateName={name}
+                            templateType={props.uploadType}
+                            variant="outlined"
+                            startIcon={<CloudDownload />}
+                        />
+                    )}
                 </Grid>
             </Grid>
-            <Grid item style={{ padding: "1em 0" }}>
+            <Box py={2}>
                 <Divider />
-            </Grid>
-            <Grid item>
-                <CIDCGithubMarkdown
-                    path={path}
-                    insertIdToken
-                    trimLeadingHeader
-                />
-            </Grid>
-        </Grid>
+            </Box>
+            <CIDCGithubMarkdown path={path} insertIdToken trimLeadingHeader />
+        </>
     );
 };
 

--- a/src/rootStyles.ts
+++ b/src/rootStyles.ts
@@ -8,18 +8,13 @@ export const colors = {
 
 export const widths = {
     maxPageWidth: 1400,
-    minPageWidth: 1100,
-    markdownWidth: 800
+    minPageWidth: 1100
 };
 
 export const useRootStyles = makeStyles(theme => ({
     root: {
         minWidth: "640px !important",
         height: "100vh"
-    },
-    markdown: {
-        width: widths.markdownWidth,
-        margin: "auto"
     },
     content: {
         paddingTop: "1rem",


### PR DESCRIPTION
Previously, documentation pages had fixed widths, which looks unnatural. Now, they fill the page as expected. Also, this PR creates a shared layout component, `PageWithSidebar`, to enforce consistency in sizing between the browse data page and the documentation pages.
<img width="1488" alt="Screen Shot 2020-10-27 at 4 25 58 PM" src="https://user-images.githubusercontent.com/14116434/97358191-456bdd00-1871-11eb-93d7-b9c8478de27a.png">
