### PR TITLE
Disallow caching of static assets

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -5,7 +5,7 @@
 BUCKET=$1
 
 # Copy the contents of the build directory to the GCS UI bucket
-gsutil -m cp -r build/* $BUCKET
+gsutil -m -h "Cache-Control:no-cache,max-age=0" cp -r build/* $BUCKET
 
 # Make all objects in the GCS UI bucket public
 gsutil iam ch allUsers:objectViewer $BUCKET


### PR DESCRIPTION
By default, GCS sets the `Cache-Control` header to `public, max-age=3600`. This change overrides that default, and should make it so that deployed UI updates appear immediately in user's browsers (that is, after the previous cached deployments with default configs go stale).