### PR TITLE
Add a meta description and valid robots.txt

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,8 @@
       }
     </style>
 
-    <title>CIMAC-CIDC Portal</title>
+    <title>CIMAC-CIDC Data Portal</title>
+    <meta name="description" content="Browse cutting-edge cancer immune monitoring and analysis data." />
   </head>
   <body>
     <noscript>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow:


### PR DESCRIPTION
Now that we have a public homepage, it's worth putting in a little effort to ensure the site appears in the results for related google searches. Adding a valid `robots.txt` and a `<meta name="description"...` tag should hopefully help our chances here.