### PR TITLE
Fix profile menu navigation

### DIFF
--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -265,7 +265,8 @@ describe("UserProfileMenu", () => {
     });
 
     it("navigates to /profile when the 'profile' option is clicked", () => {
-        history.push("/");
+        const testPath = "/pipelines/";
+        history.push(testPath);
         const { getByText, getByAltText } = renderWithRouter(
             <UserContext.Provider value={user}>
                 <Header />
@@ -275,6 +276,7 @@ describe("UserProfileMenu", () => {
         fireEvent.click(getByAltText(avatarAltText));
         fireEvent.click(getByText(/profile/i));
         expect(history.location.pathname).toContain("/profile");
+        expect(history.location.pathname).not.toContain(testPath);
     });
 
     it("calls the logout function when the 'logout' option is clicked", () => {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -118,7 +118,7 @@ const UserProfileMenu: React.FC<{ user: IAccountWithExtraContext }> = ({
                 onClose={() => setMenuAnchor(null)}
             >
                 {user.approval_date && (
-                    <MenuItem component={Link} to="profile">
+                    <MenuItem component={Link} to="/profile">
                         Profile
                     </MenuItem>
                 )}


### PR DESCRIPTION
Under current behavior, clicking the "Profile" menu option takes you from a route like `/pipelines/rna` to `/pipelines/rna/profile`. Making the profile button URL an absolute path fixes this bug.
