### PR TITLE
Auto-resizing visualizations

### DIFF
--- a/public/static/cg/clustergrammer.html
+++ b/public/static/cg/clustergrammer.html
@@ -27,11 +27,7 @@
         </style>
     </head>
     <body>
-        <div id="cg-root">
-            <div id="cg-loader">
-                Loading Clustergrammer...
-            </div>
-        </div>
+        <div id="cg-root"></div>
 
         <!-- Required JS Libraries -->
         <script src="/static/cg/lib/js/d3.min.js"></script>
@@ -50,17 +46,22 @@
             document.DrawClustergram = function(args) {
                 args.root = "#cg-root";
 
+                // Size the plot container
                 d3.select(args.root)
                     .style("width", window.innerWidth + "px")
                     .style("height", window.innerHeight - 20 + "px");
 
-                d3.select(window).on("resize", function() {
-                    resize_container(args);
-                    cgm.resize_viz();
+                // Clear previously rendered clustergrammer viz from plot container
+                const root = document.getElementById(args.root.slice(1));
+                ["viz_wrapper", "sidebar_wrapper"].forEach(cls => {
+                    const elements = document.getElementsByClassName(cls);
+                    if (elements.length == 1) {
+                        root.removeChild(elements[0]);
+                    }
                 });
 
-                cgm = Clustergrammer(args);
-                document.getElementById("cg-loader").remove();
+                // Render the plot
+                const cgm = Clustergrammer(args);
             };
         </script>
     </body>

--- a/src/components/browse-data/files/FileDetailsPage.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.tsx
@@ -32,7 +32,7 @@ import {
 import CopyToClipboardButton from "../../generic/CopyToClipboardButton";
 import { ButtonProps } from "@material-ui/core/Button";
 import Loader from "../../generic/Loader";
-import IHCBarplot from "../../visualizations/IHCBarplot";
+import IHCBarplotCard from "../../visualizations/IHCBarplotCard";
 import ClustergrammerCard from "../../visualizations/ClustergrammerCard";
 import TextWithIcon from "../../generic/TextWithIcon";
 import {
@@ -383,7 +383,7 @@ const FileDetailsPage: React.FC<RouteComponentProps<
             </Grid>
             {file.ihc_combined_plot && (
                 <Grid item xs={12}>
-                    <IHCBarplot data={file.ihc_combined_plot} />
+                    <IHCBarplotCard data={file.ihc_combined_plot} />
                 </Grid>
             )}
             {file.clustergrammer && (

--- a/src/components/generic/withResize.tsx
+++ b/src/components/generic/withResize.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box } from "@material-ui/core";
+
+interface IWidthHeight {
+    width?: number;
+    height?: number;
+}
+
+export default function withResize<
+    P extends IWidthHeight,
+    R = Omit<P, keyof IWidthHeight>
+>(Component: React.ComponentType<P>): React.ComponentType<R> {
+    const ResizableComponent: React.FC<R> = props => {
+        const boxRef = React.useRef<HTMLDivElement>();
+        const [height, setHeight] = React.useState<number | undefined>();
+        const [width, setWidth] = React.useState<number | undefined>();
+
+        const refreshBounds = React.useCallback(() => {
+            if (boxRef.current) {
+                const rect = boxRef.current.getBoundingClientRect();
+                setHeight(rect.height);
+                setWidth(rect.width);
+            }
+        }, [boxRef]);
+
+        React.useEffect(() => {
+            refreshBounds();
+            window.addEventListener("resize", refreshBounds);
+            return () => window.removeEventListener("resize", refreshBounds);
+        }, [refreshBounds]);
+
+        return (
+            <Box
+                // @ts-ignore
+                ref={boxRef}
+                width="100%"
+                height="100%"
+            >
+                {/* @ts-ignore */}
+                <Component height={height} width={width} {...props} />
+            </Box>
+        );
+    };
+    return ResizableComponent;
+}

--- a/src/components/visualizations/ClustergrammerCard.test.tsx
+++ b/src/components/visualizations/ClustergrammerCard.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import networkData from "../__data__/clustergrammerNetwork.json";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import ClustergrammerCard, { Clustergrammer } from "./ClustergrammerCard";
 import useRawFile from "../../util/useRawFile";
+import { Box } from "@material-ui/core";
 jest.mock("../../util/useRawFile");
 
 useRawFile.mockImplementation(() => {
@@ -11,13 +12,13 @@ useRawFile.mockImplementation(() => {
 
 describe("Clustergrammer", () => {
     it("loads an iframe", async () => {
-        const { baseElement } = render(
+        const { container } = render(
             <Clustergrammer networkData={networkData} />,
             { container: document.createElement("div") }
         );
 
-        const cgIframe = baseElement.childNodes[0];
-        expect(cgIframe.nodeName).toBe("IFRAME");
+        const iframe = await waitFor(() => container.querySelector("iframe"));
+        expect(iframe).not.toBe(null);
     });
 });
 

--- a/src/components/visualizations/ClustergrammerCard.tsx
+++ b/src/components/visualizations/ClustergrammerCard.tsx
@@ -12,9 +12,9 @@ import { OpenInNew } from "@material-ui/icons";
 import React from "react";
 import Frame, { FrameContextConsumer } from "react-frame-component";
 import { DataFile } from "../../model/file";
-import { widths } from "../../rootStyles";
 import useRawFile from "../../util/useRawFile";
 import ContactAnAdmin from "../generic/ContactAnAdmin";
+import withResize from "../generic/withResize";
 
 // TODO: refine this type
 export interface INetworkData {
@@ -31,36 +31,44 @@ export interface IClustergrammerProps {
  *
  * NOTE: this component renders static files stored in the `public/static/cg/` directory.
  */
-export const Clustergrammer: React.FC<IClustergrammerProps> = props => {
-    const cgHTML = useRawFile("/static/cg/clustergrammer.html");
+export const Clustergrammer = withResize<IClustergrammerProps>(
+    ({ networkData, height, width }) => {
+        const cgHTML = useRawFile("/static/cg/clustergrammer.html");
 
-    const drawCg = (iframe: {
-        document: Document & { DrawClustergram?: (cfg: any) => void };
-    }) => {
-        setTimeout(() => {
-            if (iframe.document.DrawClustergram) {
-                iframe.document.DrawClustergram({
-                    network_data: props.networkData,
-                    sidebar_width: 125
-                });
-            }
-        }, 1000);
-    };
+        const drawCg = (iframe: {
+            window: Window;
+            document: Document & { DrawClustergram?: (cfg: any) => void };
+        }) => {
+            const renderClustergrammer = () => {
+                const intervalId = setInterval(() => {
+                    if (iframe.document.DrawClustergram) {
+                        iframe.document.DrawClustergram({
+                            network_data: networkData,
+                            sidebar_width: 125
+                        });
+                        clearInterval(intervalId);
+                    }
+                }, 100);
+            };
+            renderClustergrammer();
+            window.addEventListener("onresize", renderClustergrammer);
+        };
 
-    return cgHTML ? (
-        <Frame
-            title="clustergrammer-iframe"
-            initialContent={cgHTML}
-            width={props.width || 1000}
-            height={props.height || 600}
-            frameBorder={0}
-        >
-            <FrameContextConsumer>
-                {(context: any) => drawCg(context)}
-            </FrameContextConsumer>
-        </Frame>
-    ) : null;
-};
+        return cgHTML && height && width ? (
+            <Frame
+                title="clustergrammer-iframe"
+                initialContent={cgHTML}
+                width={width}
+                height={height}
+                frameBorder={0}
+            >
+                <FrameContextConsumer>
+                    {(context: any) => drawCg(context)}
+                </FrameContextConsumer>
+            </Frame>
+        ) : null;
+    }
+);
 
 const CLUSTERGRAMMER_HELP_LINK =
     "https://clustergrammer.readthedocs.io/interacting_with_viz.html";
@@ -70,9 +78,6 @@ export interface IClustergrammerCardProps {
 }
 
 const ClustergrammerCard: React.FC<IClustergrammerCardProps> = ({ file }) => {
-    const width = widths.minPageWidth;
-    const height = 800;
-
     return (
         <Card>
             <CardHeader
@@ -92,41 +97,33 @@ const ClustergrammerCard: React.FC<IClustergrammerCardProps> = ({ file }) => {
                     </Grid>
                 }
             />
-            <CardContent style={{ overflowX: "scroll" }}>
-                <Box m="auto" width={width}>
-                    {file.clustergrammer ? (
-                        <>
-                            <Typography
-                                variant="subtitle1"
-                                paragraph
-                                gutterBottom
+            <CardContent>
+                {file.clustergrammer ? (
+                    <>
+                        <Typography variant="subtitle1" paragraph gutterBottom>
+                            <strong>Note:</strong> the rows in this
+                            visualization have been z-score normalized using
+                            Clustergrammer's built-in{" "}
+                            <Link
+                                href="https://clustergrammer.readthedocs.io/clustergrammer_py.html#clustergrammer_py.Network.normalize"
+                                target="_blank"
+                                rel="noopener noreferrer"
                             >
-                                <strong>Note:</strong> the rows in this
-                                visualization have been z-score normalized using
-                                Clustergrammer's built-in{" "}
-                                <Link
-                                    href="https://clustergrammer.readthedocs.io/clustergrammer_py.html#clustergrammer_py.Network.normalize"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    <code>normalize</code>
-                                </Link>{" "}
-                                function.
-                            </Typography>
-                            <Clustergrammer
-                                networkData={file.clustergrammer}
-                                width={width}
-                                height={height}
-                            />
-                        </>
-                    ) : (
-                        <Typography color="textSecondary">
-                            Oops! This file cannot be visualized with
-                            Clustergrammer. Please <ContactAnAdmin lower /> so
-                            we can investigate this issue.
+                                <code>normalize</code>
+                            </Link>{" "}
+                            function.
                         </Typography>
-                    )}
-                </Box>
+                        <Box height={800}>
+                            <Clustergrammer networkData={file.clustergrammer} />
+                        </Box>
+                    </>
+                ) : (
+                    <Typography color="textSecondary">
+                        Oops! This file cannot be visualized with
+                        Clustergrammer. Please <ContactAnAdmin lower /> so we
+                        can investigate this issue.
+                    </Typography>
+                )}
             </CardContent>
         </Card>
     );

--- a/src/components/visualizations/ClustergrammerCard.tsx
+++ b/src/components/visualizations/ClustergrammerCard.tsx
@@ -54,7 +54,7 @@ export const Clustergrammer = withResize<IClustergrammerProps>(
             window.addEventListener("onresize", renderClustergrammer);
         };
 
-        return cgHTML && height && width ? (
+        return cgHTML && height !== undefined && width !== undefined ? (
             <Frame
                 title="clustergrammer-iframe"
                 initialContent={cgHTML}

--- a/src/components/visualizations/IHCBarplotCard.test.tsx
+++ b/src/components/visualizations/IHCBarplotCard.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import IHCBarplot from "./IHCBarplot";
+import IHCBarplotCard from "./IHCBarplotCard";
 
 it("renders a plot when some data columns are available", () => {
     const ihcData = [
@@ -16,7 +16,7 @@ it("renders a plot when some data columns are available", () => {
         }
     ];
     const { queryByText, queryAllByText, getByText } = render(
-        <IHCBarplot data={ihcData} />
+        <IHCBarplotCard data={ihcData} />
     );
     // control panel rendered
     expect(queryByText(/color by/i)).toBeInTheDocument();
@@ -32,7 +32,9 @@ it("renders a plot when some data columns are available", () => {
 
 it("renders an error message when no data columns are available", () => {
     const ihcDataNoDataColumns = [{ foo: "bar" }];
-    const { queryByText } = render(<IHCBarplot data={ihcDataNoDataColumns} />);
+    const { queryByText } = render(
+        <IHCBarplotCard data={ihcDataNoDataColumns} />
+    );
     expect(
         queryByText(
             /failed to build an IHC expression distribution visualization/i

--- a/src/components/visualizations/IHCBarplotCard.tsx
+++ b/src/components/visualizations/IHCBarplotCard.tsx
@@ -16,13 +16,11 @@ import {
     CardHeader,
     Select,
     MenuItem,
-    Typography
+    Typography,
+    Box
 } from "@material-ui/core";
 import ContactAnAdmin from "../generic/ContactAnAdmin";
-
-export interface IHCBarplotProps {
-    data: IHCPlotData;
-}
+import withResize from "../generic/withResize";
 
 const IHC_CONFIG = {
     facets: [
@@ -96,7 +94,49 @@ const IHCPlotControls: React.FC<{
     );
 };
 
-const IHCBarplot: React.FC<IHCBarplotProps> = props => {
+interface IHCBarplotProps extends IHCBarplotCardProps {
+    data: any;
+    dataColumn: string;
+    width?: number;
+    height?: number;
+}
+
+const IHCBarplot = withResize<IHCBarplotProps>(
+    ({ data, dataColumn, width, height }) => {
+        return (
+            <Plot
+                data={data}
+                layout={{
+                    width,
+                    height,
+                    autosize: false,
+                    showlegend: true,
+                    yaxis: {
+                        anchor: "x",
+                        title: { text: dataColumn }
+                    },
+                    xaxis: {
+                        anchor: "y",
+                        title: {
+                            text: "Sample<br>(hover to view CIMAC ID)"
+                        },
+                        categorymode: "array",
+                        categoryarray: map(data, "cimac_id"),
+                        showticklabels: false
+                    },
+                    margin: { t: 10 }
+                }}
+                config={{ displaylogo: false }}
+            />
+        );
+    }
+);
+
+export interface IHCBarplotCardProps {
+    data: IHCPlotData;
+}
+
+const IHCBarplotCard: React.FC<IHCBarplotCardProps> = props => {
     const [facet, setFacet] = React.useState<string>(
         IHC_CONFIG.facets[0].value
     );
@@ -120,8 +160,14 @@ const IHCBarplot: React.FC<IHCBarplotProps> = props => {
     }));
 
     const plot = (
-        <Grid container direction="row" wrap="nowrap" spacing={1}>
-            <Grid item>
+        <Grid
+            container
+            direction="row"
+            justify="space-between"
+            wrap="nowrap"
+            spacing={1}
+        >
+            <Grid item xs={3}>
                 <IHCPlotControls
                     dataColumn={dataColumn}
                     dataColumns={dataColumns}
@@ -130,28 +176,10 @@ const IHCBarplot: React.FC<IHCBarplotProps> = props => {
                     setFacet={setFacet}
                 />
             </Grid>
-            <Grid item>
-                <Plot
-                    data={data}
-                    layout={{
-                        showlegend: true,
-                        yaxis: {
-                            anchor: "x",
-                            title: { text: dataColumn }
-                        },
-                        xaxis: {
-                            anchor: "y",
-                            title: {
-                                text: "Sample<br>(hover to view CIMAC ID)"
-                            },
-                            categorymode: "array",
-                            categoryarray: map(props.data, "cimac_id"),
-                            showticklabels: false
-                        },
-                        margin: { t: 10 }
-                    }}
-                    config={{ displaylogo: false }}
-                />
+            <Grid item xs={9}>
+                <Box height={600}>
+                    <IHCBarplot data={data} dataColumn={dataColumn} />
+                </Box>
             </Grid>
         </Grid>
     );
@@ -174,4 +202,4 @@ const IHCBarplot: React.FC<IHCBarplotProps> = props => {
     );
 };
 
-export default IHCBarplot;
+export default IHCBarplotCard;


### PR DESCRIPTION
* Add the `withResize` higher-order component
* Wrap both `Clustergrammer` and `IHCBarplot` with `withResize` so that their widths update dynamically when the window is resized
* Fix some issues with re-rendering Clustergrammer in an iframe.