### PR TITLE
Code-split across routes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,16 +1,101 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import axios from "axios";
+import { fireEvent, render } from "@testing-library/react";
 import App from "./App";
-jest.mock("axios");
-jest.mock("auth0-js");
+jest.mock("axios", () => {
+    const actualAxios = jest.requireActual("axios");
+    return {
+        ...actualAxios,
+        create: jest.fn().mockReturnValue({
+            get: jest
+                .fn()
+                .mockResolvedValue({ data: { _items: [], trial_ids: [] } })
+        })
+    };
+});
+jest.mock("./components/info/InfoProvider", () => {
+    const { InfoContext, ...actualInfoProvider } = jest.requireActual(
+        "./components/info/InfoProvider"
+    );
+
+    return {
+        __esModule: true,
+        ...actualInfoProvider,
+        InfoContext,
+        default: jest.fn().mockImplementation(props => {
+            return (
+                <InfoContext.Provider
+                    value={{ supportedTemplates: { manifests: [] } }}
+                >
+                    {props.children}
+                </InfoContext.Provider>
+            );
+        })
+    };
+});
+
+jest.mock("./components/identity/IdentityProvider", () => {
+    const { AuthContext } = jest.requireActual(
+        "./components/identity/AuthProvider"
+    );
+    const { UserContext } = jest.requireActual(
+        "./components/identity/UserProvider"
+    );
+    const actualIdentityProvider = jest.requireActual(
+        "./components/identity/IdentityProvider"
+    );
+
+    return {
+        __esModule: true,
+        ...actualIdentityProvider,
+        default: jest.fn().mockImplementation(props => {
+            return (
+                <AuthContext.Provider
+                    value={{
+                        state: "logged-in",
+                        userInfo: { idToken: "test-token" }
+                    }}
+                >
+                    <UserContext.Provider
+                        value={{
+                            approval_date: "1/1/1",
+                            showAssays: true,
+                            showManifests: true,
+                            showAnalyses: true
+                        }}
+                    >
+                        {props.children}
+                    </UserContext.Provider>
+                </AuthContext.Provider>
+            );
+        })
+    };
+});
 
 it("renders without crashing", () => {
-    axios.create.mockReturnValue({
-        get: () => Promise.resolve({})
-    });
-
     const div = document.createElement("div");
     ReactDOM.render(<App />, div);
     ReactDOM.unmountComponentAtNode(div);
+});
+
+test("users can navigate to pages as expected", async () => {
+    const { getByText, findByText, findByTitle } = render(<App />);
+
+    fireEvent.click(getByText(/browse data/i));
+    expect(await findByText(/trial view/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/pipelines/i));
+    expect(await findByText(/rima/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/transfer assays/i));
+    expect(await findByText(/the cidc cli/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/schema/i));
+    expect(await findByTitle(/cidc schema/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/analyses/i));
+    expect(await findByText(/the cidc cli/i)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/manifests/i));
+    expect(await findByText(/empty manifest template/)).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,8 @@ import {
     AssayDocsPage,
     AnalysesDocsPage
 } from "./components/upload-docs/UploadDocsPages";
-import Loader from "./components/generic/Loader";
 
+// Code-split across different routes on the site
 const HomePage = React.lazy(() => import("./components/home/HomePage"));
 const ManifestsPage = React.lazy(() =>
     import("./components/manifests/ManifestsPage")
@@ -51,7 +51,7 @@ export default function App() {
                                 <IdentityProvider>
                                     <Header />
                                     <div className={classes.content}>
-                                        <React.Suspense fallback={<Loader />}>
+                                        <React.Suspense fallback={null}>
                                             <Switch>
                                                 <Route
                                                     exact

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,42 @@
 import * as React from "react";
-import BrowseDataPage from "./components/browse-data/BrowseDataPage";
-import FileDetailsPage from "./components/browse-data/files/FileDetailsPage";
 import { Router, Switch, Route } from "react-router-dom";
 import Header from "./components/header/Header";
 import Footer from "./components/footer/Footer";
-import HomePage from "./components/home/HomePage";
-import ManifestsPage from "./components/manifests/ManifestsPage";
-import PrivacyAndSecurityPage from "./components/privacy-and-security/PrivacyAndSecurityPage";
-import ProfilePage from "./components/profile/ProfilePage";
-import Register from "./components/identity/Register";
 import history from "./components/identity/History";
 import ErrorGuard from "./components/errors/ErrorGuard";
 import InfoProvider from "./components/info/InfoProvider";
 import { CIDCThemeProvider, useRootStyles } from "./rootStyles";
 import { QueryParamProvider } from "use-query-params";
+import NotFoundRoute from "./components/generic/NotFoundRoute";
+import IdentityProvider from "./components/identity/IdentityProvider";
 import {
     AssayDocsPage,
     AnalysesDocsPage
 } from "./components/upload-docs/UploadDocsPages";
-import SchemaPage from "./components/schema/SchemaPage";
-import PipelinesPage from "./components/pipelines/PipelinesPage";
-import NotFoundRoute from "./components/generic/NotFoundRoute";
-import IdentityProvider from "./components/identity/IdentityProvider";
+import Loader from "./components/generic/Loader";
+
+const HomePage = React.lazy(() => import("./components/home/HomePage"));
+const ManifestsPage = React.lazy(() =>
+    import("./components/manifests/ManifestsPage")
+);
+const PrivacyAndSecurityPage = React.lazy(() =>
+    import("./components/privacy-and-security/PrivacyAndSecurityPage")
+);
+const ProfilePage = React.lazy(() =>
+    import("./components/profile/ProfilePage")
+);
+const Register = React.lazy(() => import("./components/identity/Register"));
+
+const SchemaPage = React.lazy(() => import("./components/schema/SchemaPage"));
+const PipelinesPage = React.lazy(() =>
+    import("./components/pipelines/PipelinesPage")
+);
+const BrowseDataPage = React.lazy(() =>
+    import("./components/browse-data/BrowseDataPage")
+);
+const FileDetailsPage = React.lazy(() =>
+    import("./components/browse-data/files/FileDetailsPage")
+);
 
 export default function App() {
     const classes = useRootStyles();
@@ -36,66 +51,68 @@ export default function App() {
                                 <IdentityProvider>
                                     <Header />
                                     <div className={classes.content}>
-                                        <Switch>
-                                            <Route
-                                                exact
-                                                path="/"
-                                                component={HomePage}
-                                            />
-                                            <Route
-                                                path="/assays"
-                                                component={AssayDocsPage}
-                                            />
-                                            <Route
-                                                path="/analyses"
-                                                component={AnalysesDocsPage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/browse-data/:fileId"
-                                                component={FileDetailsPage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/browse-data"
-                                                component={BrowseDataPage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/manifests"
-                                                component={ManifestsPage}
-                                            />
-                                            <Route
-                                                path="/pipelines"
-                                                component={PipelinesPage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/schema"
-                                                component={SchemaPage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/privacy-security"
-                                                component={
-                                                    PrivacyAndSecurityPage
-                                                }
-                                            />
-                                            <Route
-                                                exact
-                                                path="/profile"
-                                                component={ProfilePage}
-                                            />
-                                            <Route
-                                                exact
-                                                path="/register"
-                                                component={Register}
-                                            />
-                                            <Route
-                                                path="*"
-                                                component={NotFoundRoute}
-                                            />
-                                        </Switch>
+                                        <React.Suspense fallback={<Loader />}>
+                                            <Switch>
+                                                <Route
+                                                    exact
+                                                    path="/"
+                                                    component={HomePage}
+                                                />
+                                                <Route
+                                                    path="/assays"
+                                                    component={AssayDocsPage}
+                                                />
+                                                <Route
+                                                    path="/analyses"
+                                                    component={AnalysesDocsPage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/browse-data/:fileId"
+                                                    component={FileDetailsPage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/browse-data"
+                                                    component={BrowseDataPage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/manifests"
+                                                    component={ManifestsPage}
+                                                />
+                                                <Route
+                                                    path="/pipelines"
+                                                    component={PipelinesPage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/schema"
+                                                    component={SchemaPage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/privacy-security"
+                                                    component={
+                                                        PrivacyAndSecurityPage
+                                                    }
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/profile"
+                                                    component={ProfilePage}
+                                                />
+                                                <Route
+                                                    exact
+                                                    path="/register"
+                                                    component={Register}
+                                                />
+                                                <Route
+                                                    path="*"
+                                                    component={NotFoundRoute}
+                                                />
+                                            </Switch>
+                                        </React.Suspense>
                                     </div>
                                     <Footer />
                                 </IdentityProvider>


### PR DESCRIPTION
Using `React.lazy`, only load the javascript bundle for each page on the site if the user visits that page. This will reduce the size of the initial javascript bundle sent to users' browsers.