### PR TITLE
Cancel conflicting Trial Browser filter requests

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Account } from "../model/account";
 import { Trial, NewTrial } from "../model/trial";
 import { DataFile } from "../model/file";
@@ -5,7 +6,8 @@ import axios, {
     AxiosInstance,
     AxiosResponse,
     AxiosError,
-    CancelToken
+    CancelToken,
+    CancelTokenSource
 } from "axios";
 import Permission from "../model/permission";
 import { IFacets } from "../components/browse-data/shared/FilterProvider";
@@ -325,6 +327,25 @@ function getDataOverview(): Promise<IDataOverview> {
         .get("/info/data_overview")
         .then(_extractItem);
 }
+
+export const useCancelToken = (message = "cancelling stale request") => {
+    const cancellerRef = React.useRef<CancelTokenSource | undefined>();
+
+    return {
+        get: () => {
+            if (cancellerRef.current) {
+                cancellerRef.current.cancel(message);
+            }
+            cancellerRef.current = axios.CancelToken.source();
+            return cancellerRef.current.token;
+        },
+        catchCancellation: (err: any) => {
+            if (err.message !== message) {
+                throw err;
+            }
+        }
+    };
+};
 
 export {
     _getItem,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -122,10 +122,19 @@ function getAccountInfo(token: string): Promise<Account> {
         .then(_extractItem);
 }
 
-function getTrials(token: string, params: any = {}): Promise<Trial[]> {
+function getTrials(
+    token: string,
+    params: any = {},
+    cancelToken?: CancelToken
+): Promise<Trial[]> {
     return getApiClient(token)
         .get("trial_metadata", {
-            params: { sort_field: "trial_id", sort_direction: "asc", ...params }
+            params: {
+                sort_field: "trial_id",
+                sort_direction: "asc",
+                ...params
+            },
+            cancelToken
         })
         .then(_extractItems);
 }

--- a/src/components/browse-data/BrowseDataPage.test.tsx
+++ b/src/components/browse-data/BrowseDataPage.test.tsx
@@ -4,33 +4,46 @@ import history from "../identity/History";
 import BrowseDataPage from "./BrowseDataPage";
 import { renderAsRouteComponent } from "../../../test/helpers";
 import { getFiles, getFilterFacets, getTrials } from "../../api/api";
-jest.mock("../../api/api");
 
-test("trial view / file view toggle", () => {
+jest.mock("../../api/api", () => {
+    const actualApi = jest.requireActual("../../api/api");
+    return {
+        __esModule: true,
+        ...actualApi,
+        getTrials: jest.fn(),
+        getFiles: jest.fn(),
+        getFilterFacets: jest.fn()
+    };
+});
+
+test("trial view / file view toggle", async () => {
     getTrials.mockResolvedValue([]);
     getFiles.mockResolvedValue({ data: [], meta: { total: 0 } });
     getFilterFacets.mockResolvedValue({ trial_ids: [], facets: {} });
 
-    const { queryByText, getByText } = renderAsRouteComponent(BrowseDataPage, {
-        history
-    });
-    const trialViewText = /browse trial overviews/i;
-    const fileViewText = /select files for batch download/i;
+    const { findByText, queryByText, getByText } = renderAsRouteComponent(
+        BrowseDataPage,
+        {
+            history
+        }
+    );
+    const trialViewText = /loaded all results/i;
+    const fileViewText = /no data found for these filters/i;
 
     // Trial view renders first by default
     expect(history.location.search).not.toContain("file_view=1");
-    expect(queryByText(trialViewText)).toBeInTheDocument();
+    expect(await findByText(trialViewText)).toBeInTheDocument();
     expect(queryByText(fileViewText)).not.toBeInTheDocument();
 
     // Toggle view to file view
     fireEvent.click(getByText(/file view/i));
     expect(history.location.search).toContain("file_view=1");
-    expect(queryByText(fileViewText)).toBeInTheDocument();
+    expect(await findByText(fileViewText)).toBeInTheDocument();
     expect(queryByText(trialViewText)).not.toBeInTheDocument();
 
     // Toggle view back to trial view
     fireEvent.click(getByText(/trial view/i));
     expect(history.location.search).not.toContain("file_view=1");
-    expect(queryByText(trialViewText)).toBeInTheDocument();
+    expect(await findByText(trialViewText)).toBeInTheDocument();
     expect(queryByText(fileViewText)).not.toBeInTheDocument();
 });

--- a/src/components/browse-data/files/FileTable.test.tsx
+++ b/src/components/browse-data/files/FileTable.test.tsx
@@ -7,7 +7,16 @@ import { DataFile } from "../../../model/file";
 import { AuthContext } from "../../identity/AuthProvider";
 import FileTable, { filterParams, ObjectURL, sortParams } from "./FileTable";
 import history from "../../identity/History";
-jest.mock("../../../api/api");
+
+jest.mock("../../../api/api", () => {
+    const actualApi = jest.requireActual("../../../api/api");
+    return {
+        __esModule: true,
+        ...actualApi,
+        getFiles: jest.fn(),
+        getFilelist: jest.fn()
+    };
+});
 
 test("filterParams", () => {
     expect(filterParams({})).toEqual({});

--- a/src/components/browse-data/trials/TrialTable.test.tsx
+++ b/src/components/browse-data/trials/TrialTable.test.tsx
@@ -4,8 +4,10 @@ import { range } from "lodash";
 import { renderWithRouter } from "../../../../test/helpers";
 import { getTrials } from "../../../api/api";
 import { AuthContext } from "../../identity/AuthProvider";
-import { FilterContext } from "../shared/FilterProvider";
-import TrialTable, { TrialCard } from "./TrialTable";
+import { FilterContext, IFilterContext } from "../shared/FilterProvider";
+import TrialTable, { TrialCard, usePaginatedTrials } from "./TrialTable";
+import { act, renderHook } from "@testing-library/react-hooks";
+import { CancelToken } from "axios";
 jest.mock("../../../api/api");
 
 const fileBundle = {
@@ -139,9 +141,9 @@ it("handles pagination as expected", async () => {
 it("filters by trial id", async () => {
     getTrials.mockImplementation((token: string, params: any) => {
         expect(params.trial_ids).toBe("test-trial-0,test-trial-1");
-        return Promise.resolve(trialsPageOne);
+        return Promise.resolve(trialsPageOne.slice(0, 2));
     });
-    const { findByText } = renderWithRouter(
+    const { findByText, queryByText } = renderWithRouter(
         <AuthContext.Provider value={{ idToken: "test-token" }}>
             <FilterContext.Provider
                 value={{
@@ -154,7 +156,9 @@ it("filters by trial id", async () => {
             </FilterContext.Provider>
         </AuthContext.Provider>
     );
-    await findByText(/test-trial-0/i);
+    expect(await findByText(/test-trial-0/i)).toBeInTheDocument();
+    expect(queryByText(/test-trial-1/i)).toBeInTheDocument();
+    expect(queryByText(/test-trial-2/i)).not.toBeInTheDocument();
     expect(getTrials).toHaveBeenCalled();
 });
 
@@ -167,4 +171,54 @@ test("TrialCard links out to clinicaltrials.gov", () => {
     expect(nctLink.href).toBe(
         "https://clinicaltrials.gov/ct2/show/NCT11111111"
     );
+});
+
+test("usePaginatedTrials appears not to have a race condition", async () => {
+    let allCallsMade = false;
+    getTrials
+        .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
+            await new Promise(r => setTimeout(r, 400));
+            cancelToken.throwIfRequested();
+            return trialsPageOne;
+        })
+        .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
+            cancelToken.throwIfRequested();
+            return trialsPageOne.slice(0, 2);
+        })
+        .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
+            await new Promise(r => setTimeout(r, 100));
+            cancelToken.throwIfRequested();
+            return trialsPageOne.slice(3, 6);
+        })
+        .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
+            await new Promise(r => setTimeout(r, 500));
+            cancelToken.throwIfRequested();
+            allCallsMade = true;
+            return trialsPageOne.slice(7, 9);
+        });
+
+    const wrapper: React.FC<any> = ({ children, filters }) => (
+        <FilterContext.Provider value={{ filters }}>
+            {children}
+        </FilterContext.Provider>
+    );
+    const { rerender, result, waitFor } = renderHook(
+        () => usePaginatedTrials("token"),
+        {
+            wrapper,
+            initialProps: { filters: { trial_ids: [] } }
+        }
+    );
+    // The actual filter values don't matter here, because the API responses
+    // are mocked to return values independent of these filters. What matters
+    // is that the filters change between each render.
+    rerender({ filters: { trial_ids: ["test-trial-0"] } });
+    rerender({ filters: { trial_ids: ["test-trial-1"] } });
+    rerender({ filters: { trial_ids: ["test-trial-2"] } });
+
+    await waitFor(() => expect(allCallsMade).toBe(true));
+
+    expect(result.current.allLoaded).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.trials).toEqual(trialsPageOne.slice(7, 9));
 });

--- a/src/components/browse-data/trials/TrialTable.test.tsx
+++ b/src/components/browse-data/trials/TrialTable.test.tsx
@@ -184,7 +184,7 @@ test("TrialCard links out to clinicaltrials.gov", () => {
 test("usePaginatedTrials appears not to have a race condition", async () => {
     getTrials
         .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
-            await new Promise(r => setTimeout(r, 400));
+            await new Promise(r => setTimeout(r, 1000));
             cancelToken.throwIfRequested();
             return trialsPageOne;
         })
@@ -199,7 +199,7 @@ test("usePaginatedTrials appears not to have a race condition", async () => {
             return trialsPageOne.slice(3, 6);
         })
         .mockImplementation(async (t, p, cancelToken: CancelToken) => {
-            await new Promise(r => setTimeout(r, 500));
+            await new Promise(r => setTimeout(r, 300));
             cancelToken.throwIfRequested();
             return trialsPageOne.slice(7, 9);
         });

--- a/src/components/browse-data/trials/TrialTable.test.tsx
+++ b/src/components/browse-data/trials/TrialTable.test.tsx
@@ -8,7 +8,15 @@ import { FilterContext, IFilterContext } from "../shared/FilterProvider";
 import TrialTable, { TrialCard, usePaginatedTrials } from "./TrialTable";
 import { act, renderHook } from "@testing-library/react-hooks";
 import { CancelToken } from "axios";
-jest.mock("../../../api/api");
+
+jest.mock("../../../api/api", () => {
+    const actualApi = jest.requireActual("../../../api/api");
+    return {
+        __esModule: true,
+        ...actualApi,
+        getTrials: jest.fn()
+    };
+});
 
 const fileBundle = {
     IHC: {
@@ -190,7 +198,7 @@ test("usePaginatedTrials appears not to have a race condition", async () => {
             cancelToken.throwIfRequested();
             return trialsPageOne.slice(3, 6);
         })
-        .mockImplementationOnce(async (t, p, cancelToken: CancelToken) => {
+        .mockImplementation(async (t, p, cancelToken: CancelToken) => {
             await new Promise(r => setTimeout(r, 500));
             cancelToken.throwIfRequested();
             allCallsMade = true;

--- a/src/components/browse-data/trials/TrialTable.tsx
+++ b/src/components/browse-data/trials/TrialTable.tsx
@@ -347,10 +347,10 @@ export const usePaginatedTrials = (token: string) => {
     }, [filters.trial_ids]);
 
     React.useEffect(() => {
-        if (page === 0 && isLoading !== true) {
+        if (page === 0 && trials === undefined) {
             loadMore();
         }
-    }, [page, isLoading, loadMore]);
+    }, [page, trials, loadMore]);
 
     return {
         trials,


### PR DESCRIPTION
A race condition in `usePaginatedTrials` causes the trial browser to end up in weird states, e.g. displaying duplicate cards. This PR aims to fix that race by cancelling previous uncompleted requests for trials.