### PR TITLE
New upload process UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import {
 } from "./components/upload-docs/UploadDocsPages";
 import { SWRConfig } from "swr";
 import { apiFetch } from "./api/api";
-import TransferDataPage from "./components/transer-data/TransferDataPage";
 
 // Code-split across different routes on the site
 const HomePage = React.lazy(() => import("./components/home/HomePage"));
@@ -39,6 +38,9 @@ const BrowseDataPage = React.lazy(() =>
 );
 const FileDetailsPage = React.lazy(() =>
     import("./components/browse-data/files/FileDetailsPage")
+);
+const TransferDataPage = React.lazy(() =>
+    import("./components/transer-data/TransferDataPage")
 );
 
 export default function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from "./components/upload-docs/UploadDocsPages";
 import { SWRConfig } from "swr";
 import { apiFetch } from "./api/api";
+import TransferDataPage from "./components/transer-data/TransferDataPage";
 
 // Code-split across different routes on the site
 const HomePage = React.lazy(() => import("./components/home/HomePage"));
@@ -85,6 +86,13 @@ export default function App() {
                                                         path="/browse-data"
                                                         component={
                                                             BrowseDataPage
+                                                        }
+                                                    />
+                                                    <Route
+                                                        exact
+                                                        path="/transfer-data"
+                                                        component={
+                                                            TransferDataPage
                                                         }
                                                     />
                                                     <Route

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -14,7 +14,8 @@ import {
     TabProps,
     Box,
     Menu,
-    MenuItem
+    MenuItem,
+    Chip
 } from "@material-ui/core";
 import {
     withRouter,
@@ -268,7 +269,22 @@ const Header: React.FunctionComponent<RouteComponentProps> = props => {
 
                                         (user.showAssays ||
                                             user.showAnalyses) && {
-                                            label: "transfer data",
+                                            label: (
+                                                <div>
+                                                    transfer data{" "}
+                                                    <Box
+                                                        display="inline"
+                                                        pl={1}
+                                                    >
+                                                        <Chip
+                                                            size="small"
+                                                            label="new"
+                                                            variant="outlined"
+                                                            color="primary"
+                                                        />
+                                                    </Box>
+                                                </div>
+                                            ),
                                             value: "/transfer-data"
                                         },
                                         user.showAssays && {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -265,9 +265,19 @@ const Header: React.FunctionComponent<RouteComponentProps> = props => {
                                             label: "browse data",
                                             value: "/browse-data"
                                         },
-                                        user.showAssays && {
+
+                                        (user.showAssays ||
+                                            user.showAnalyses) && {
                                             label: "transfer data",
                                             value: "/transfer-data"
+                                        },
+                                        user.showAssays && {
+                                            label: "transfer assays",
+                                            value: "/assays"
+                                        },
+                                        user.showAnalyses && {
+                                            label: "transfer analyses",
+                                            value: "/analyses"
                                         },
                                         user.showManifests && {
                                             label: "transfer manifests",

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -266,12 +266,8 @@ const Header: React.FunctionComponent<RouteComponentProps> = props => {
                                             value: "/browse-data"
                                         },
                                         user.showAssays && {
-                                            label: "transfer assays",
-                                            value: "/assays"
-                                        },
-                                        user.showAnalyses && {
-                                            label: "transfer analyses",
-                                            value: "/analyses"
+                                            label: "transfer data",
+                                            value: "/transfer-data"
                                         },
                                         user.showManifests && {
                                             label: "transfer manifests",

--- a/src/components/info/InfoProvider.tsx
+++ b/src/components/info/InfoProvider.tsx
@@ -35,4 +35,8 @@ const InfoProvider: React.FunctionComponent = props => {
     );
 };
 
+export const useInfoContext = () => {
+    return React.useContext(InfoContext)!;
+};
+
 export default InfoProvider;

--- a/src/components/transer-data/TransferDataPage.test.tsx
+++ b/src/components/transer-data/TransferDataPage.test.tsx
@@ -1,0 +1,72 @@
+import { range } from "lodash";
+import React from "react";
+import TransferDataPage from "./TransferDataPage";
+import { apiCreate, apiFetch } from "../../api/api";
+import { InfoContext } from "../info/InfoProvider";
+import { renderWithUserContext } from "../../../test/helpers";
+import { fireEvent } from "@testing-library/react";
+jest.mock("../../api/api");
+
+const trials = [{ trial_id: "test-trial-0" }];
+const assays = ["wes"];
+const analyses = ["wes_analysis"];
+const gcsURI = "gs://cidc-intake-test/test-trial-0/wes/testuser-123";
+
+const renderWithInfoContext = () =>
+    renderWithUserContext(
+        <InfoContext.Provider
+            value={{ supportedTemplates: { assays, analyses } }}
+        >
+            <TransferDataPage />
+        </InfoContext.Provider>
+    );
+
+it("works as expected", async () => {
+    apiFetch.mockResolvedValue({ _items: trials });
+    apiCreate.mockImplementation(
+        async (url: string, token: string, config: any) => {
+            if (url === "/ingestion/intake_gcs_uri") {
+                return gcsURI;
+            }
+        }
+    );
+
+    const {
+        getByLabelText,
+        getByText,
+        findByText,
+        queryByText
+    } = renderWithInfoContext();
+
+    expect(apiFetch).toHaveBeenCalled();
+
+    // Select trial and assay
+    fireEvent.mouseDown(getByLabelText(/protocol identifier/i));
+    fireEvent.click(await findByText(/test-trial-0/i));
+    fireEvent.mouseDown(getByLabelText(/upload type/i));
+    fireEvent.click(await findByText(/wes_analysis/i));
+
+    // Initiate data transfer
+    fireEvent.click(getByText(/initiate data transfer/i));
+
+    // gsutil command with generated URI should appear
+    expect(
+        await findByText(
+            new RegExp(`gsutil -m cp -r <local data directory> ${gcsURI}`, "i")
+        )
+    ).toBeInTheDocument();
+
+    // API should've been called correctly
+    expect(apiCreate).toHaveBeenCalledWith(
+        "/ingestion/intake_gcs_uri",
+        "test-token",
+        { data: { trial_id: "test-trial-0", upload_type: "wes_analysis" } }
+    );
+
+    // Template download button should appear
+    const templateButton = queryByText(/wes_analysis template/i);
+    expect(templateButton).toBeInTheDocument();
+    expect(templateButton?.closest("button")).not.toBeNull();
+
+    // Manifest submission form should work as expected
+});

--- a/src/components/transer-data/TransferDataPage.test.tsx
+++ b/src/components/transer-data/TransferDataPage.test.tsx
@@ -4,12 +4,14 @@ import TransferDataPage from "./TransferDataPage";
 import { apiCreate, apiFetch } from "../../api/api";
 import { InfoContext } from "../info/InfoProvider";
 import { renderWithUserContext } from "../../../test/helpers";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 jest.mock("../../api/api");
 
 const trials = [{ trial_id: "test-trial-0" }];
 const assays = ["wes"];
 const analyses = ["wes_analysis"];
+const metadataFile = new File(["fake metadata xlsx"], "metadata.xlsx");
+const description = "a test description of this upload";
 const gcsURI = "gs://cidc-intake-test/test-trial-0/wes/testuser-123";
 
 const renderWithInfoContext = () =>
@@ -69,4 +71,13 @@ it("works as expected", async () => {
     expect(templateButton?.closest("button")).not.toBeNull();
 
     // Manifest submission form should work as expected
+    fireEvent.change(getByLabelText(/metadata spreadsheet/i), {
+        target: { files: [metadataFile] }
+    });
+    fireEvent.change(getByLabelText(/description/i), {
+        target: { value: description }
+    });
+    fireEvent.click(getByText(/upload metadata/i));
+
+    await waitFor(() => expect(apiCreate).toHaveBeenCalled());
 });

--- a/src/components/transer-data/TransferDataPage.tsx
+++ b/src/components/transer-data/TransferDataPage.tsx
@@ -289,6 +289,9 @@ const TransferDataForm: React.FC = withIdToken(({ token }) => {
                                                         id="metadata-file"
                                                         name="xlsx"
                                                         type="file"
+                                                        inputProps={{
+                                                            accept: ".xlsx"
+                                                        }}
                                                     />
                                                 </FormControl>
                                             </Grid>

--- a/src/components/transer-data/TransferDataPage.tsx
+++ b/src/components/transer-data/TransferDataPage.tsx
@@ -55,7 +55,7 @@ const TransferDataForm: React.FC = withIdToken(({ token }) => {
     return (
         <Card style={{ maxWidth: 800 }}>
             <CardHeader title="Transfer data" />
-            <CardContent>
+            <CardContent className="markdown-body">
                 <Typography gutterBottom>
                     Select the trial and assay type you wish to transfer data
                     for to generate a Google Cloud Storage transfer destination.
@@ -82,7 +82,7 @@ const TransferDataForm: React.FC = withIdToken(({ token }) => {
                         }).then(gcsURI => setURL(gcsURI));
                     })}
                 >
-                    <Grid container spacing={3} style={{ maxWidth: 800 }}>
+                    <Grid container spacing={3}>
                         <Grid item xs={6}>
                             <FormControl fullWidth>
                                 <InputLabel id="protocol-identifier-label">
@@ -179,12 +179,7 @@ const TransferDataForm: React.FC = withIdToken(({ token }) => {
                             steps:
                         </Typography>
                         <Box px={2}>
-                            <Grid
-                                container
-                                className="markdown-body"
-                                direction="column"
-                                spacing={1}
-                            >
+                            <Grid container direction="column" spacing={1}>
                                 <Grid item>
                                     <Typography variant="h4">
                                         1. Upload your data with{" "}
@@ -202,12 +197,10 @@ const TransferDataForm: React.FC = withIdToken(({ token }) => {
                                         containing the data you wish to upload,
                                         run a command like:
                                     </Typography>
-                                    <pre>
-                                        <code className="language-bash">
-                                            gsutil -m cp -r{" "}
-                                            {"<local data directory>"} {url}
-                                        </code>
-                                    </pre>
+                                    <code className="language-bash">
+                                        gsutil -m cp -r{" "}
+                                        {"<local data directory>"} {url}
+                                    </code>
                                 </Grid>
                                 <Grid item>
                                     <Typography variant="h4">

--- a/src/components/transer-data/TransferDataPage.tsx
+++ b/src/components/transer-data/TransferDataPage.tsx
@@ -1,0 +1,355 @@
+import React from "react";
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CircularProgress,
+    Divider,
+    FormControl,
+    FormLabel,
+    Grid,
+    Input,
+    InputLabel,
+    Link,
+    MenuItem,
+    Select,
+    TextField,
+    Typography
+} from "@material-ui/core";
+import { useRootStyles } from "../../rootStyles";
+import { withIdToken } from "../identity/AuthProvider";
+import { useForm } from "react-hook-form";
+import ContactAnAdmin from "../generic/ContactAnAdmin";
+import { apiCreate, IApiPage } from "../../api/api";
+import { useInfoContext } from "../info/InfoProvider";
+import useSWR from "swr";
+import { Trial } from "../../model/trial";
+import { Alert } from "@material-ui/lab";
+import TemplateDownloadButton from "../generic/TemplateDownloadButton";
+import { CloudDownload } from "@material-ui/icons";
+import { RouteComponentProps } from "react-router-dom";
+
+const TransferDataForm: React.FC = withIdToken(({ token }) => {
+    const info = useInfoContext();
+    const uploadTypes = [
+        ...info.supportedTemplates.assays,
+        ...info.supportedTemplates.analyses
+    ];
+    const { data } = useSWR<IApiPage<Trial>>([
+        "/trial_metadata?page_size=200",
+        token
+    ]);
+    const trialIds = data?._items.map(t => t.trial_id);
+    const noTrialPermissions = trialIds?.length === 0;
+
+    const { register, handleSubmit } = useForm();
+    const [trialId, setTrialId] = React.useState<string | undefined>();
+    const [uploadType, setUploadType] = React.useState<string | undefined>();
+    const [url, setURL] = React.useState<string | undefined>();
+    const [uploadSuccess, setUploadSuccess] = React.useState<boolean>(false);
+
+    const isLoadingURL = trialId && uploadType && url === undefined;
+
+    return (
+        <Card style={{ maxWidth: 800 }}>
+            <CardHeader title="Transfer data" />
+            <CardContent>
+                <Typography gutterBottom>
+                    Select the trial and assay type you wish to transfer data
+                    for to generate a Google Cloud Storage transfer destination.
+                </Typography>
+                {noTrialPermissions && (
+                    <Alert severity="error">
+                        <Typography>
+                            You don't have permission to upload to any CIMAC
+                            trials. Please <ContactAnAdmin lower /> to request
+                            permissions.
+                        </Typography>
+                    </Alert>
+                )}
+                <form
+                    onSubmit={handleSubmit(formData => {
+                        setURL(undefined);
+                        setTrialId(formData.trialId);
+                        setUploadType(formData.uploadType);
+                        apiCreate<string>("/ingestion/intake_gcs_uri", token, {
+                            data: {
+                                trial_id: formData.trialId,
+                                upload_type: formData.uploadType
+                            }
+                        }).then(gcsURI => setURL(gcsURI));
+                    })}
+                >
+                    <Grid container spacing={3} style={{ maxWidth: 800 }}>
+                        <Grid item xs={6}>
+                            <FormControl fullWidth>
+                                <InputLabel id="protocol-identifier-label">
+                                    Protocol Identifier
+                                </InputLabel>
+                                <Select
+                                    labelId="protocol-identifier-label"
+                                    id="protocol-identifier-select"
+                                    defaultValue=""
+                                    inputRef={ref =>
+                                        ref &&
+                                        register({
+                                            name: "trialId",
+                                            value: ref.value
+                                        })
+                                    }
+                                    required
+                                >
+                                    {trialIds ? (
+                                        trialIds.map(tid => (
+                                            <MenuItem key={tid} value={tid}>
+                                                {tid}
+                                            </MenuItem>
+                                        ))
+                                    ) : (
+                                        <MenuItem disabled>
+                                            loading trials...
+                                        </MenuItem>
+                                    )}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={6}>
+                            <FormControl fullWidth>
+                                <InputLabel id="upload-type-label">
+                                    Upload Type
+                                </InputLabel>
+                                <Select
+                                    labelId="upload-type-label"
+                                    id="upload-type-select"
+                                    defaultValue=""
+                                    inputRef={ref =>
+                                        ref &&
+                                        register({
+                                            name: "uploadType",
+                                            value: ref.value
+                                        })
+                                    }
+                                    required
+                                >
+                                    {uploadTypes.map(ut => (
+                                        <MenuItem key={ut} value={ut}>
+                                            {ut}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item>
+                            <Grid container alignItems="center" spacing={3}>
+                                <Grid item>
+                                    <Button
+                                        type="submit"
+                                        variant="contained"
+                                        color="primary"
+                                        disabled={
+                                            !trialIds || noTrialPermissions
+                                        }
+                                    >
+                                        Initiate data transfer
+                                    </Button>
+                                </Grid>
+                                {(trialIds === undefined || isLoadingURL) && (
+                                    <Grid item>
+                                        <CircularProgress size={24} />
+                                    </Grid>
+                                )}
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </form>
+                {url && trialId && uploadType && (
+                    <>
+                        <Box my={3}>
+                            <Divider />
+                        </Box>
+
+                        <Typography>
+                            Your transfer destination is{" "}
+                            <strong>
+                                <code>{url}</code>
+                            </strong>
+                            . To complete your data transfer, follow these
+                            steps:
+                        </Typography>
+                        <Box px={2}>
+                            <Grid
+                                container
+                                className="markdown-body"
+                                direction="column"
+                                spacing={1}
+                            >
+                                <Grid item>
+                                    <Typography variant="h4">
+                                        1. Upload your data with{" "}
+                                        <Link
+                                            href="https://cloud.google.com/storage/docs/gsutil_install"
+                                            target="_blank"
+                                            rel="noreferrer nopopener"
+                                        >
+                                            <code>gsutil</code>
+                                        </Link>
+                                        .
+                                    </Typography>
+                                    <Typography>
+                                        From the root of the directory
+                                        containing the data you wish to upload,
+                                        run a command like:
+                                    </Typography>
+                                    <pre>
+                                        <code className="language-bash">
+                                            gsutil -m cp -r{" "}
+                                            {"<local data directory>"} {url}
+                                        </code>
+                                    </pre>
+                                </Grid>
+                                <Grid item>
+                                    <Typography variant="h4">
+                                        2. Download an empty metadata template
+                                        and populate it with your upload info.
+                                    </Typography>
+                                    <Typography>
+                                        Please ensure all filepaths that you
+                                        provide are relative to the root of your
+                                        local upload directory.
+                                    </Typography>
+                                    <TemplateDownloadButton
+                                        verboseLabel
+                                        templateName={uploadType}
+                                        templateType={
+                                            info.supportedTemplates.assays.includes(
+                                                uploadType
+                                            )
+                                                ? "assays"
+                                                : "analyses"
+                                        }
+                                        variant="contained"
+                                        color="primary"
+                                        endIcon={<CloudDownload />}
+                                    />
+                                </Grid>
+                                <Grid item>
+                                    <Typography variant="h4">
+                                        3. Upload your metadata spreadsheet,
+                                        along with a brief description of the
+                                        upload.
+                                    </Typography>
+                                    <Typography>
+                                        Filling out this form sends your
+                                        metadata spreadsheet directly to CIDC
+                                        Admins for review. Data included in this
+                                        upload will not appear in the CIDC until
+                                        CIDC Admins finalize its ingestion.
+                                        Admins may reach out via email for
+                                        clarification or feedback during this
+                                        process.
+                                    </Typography>
+                                    <form
+                                        onChange={() => setUploadSuccess(false)}
+                                        onSubmit={e => {
+                                            const formData = new FormData(
+                                                e.currentTarget
+                                            );
+                                            formData.append(
+                                                "trial_id",
+                                                trialId
+                                            );
+                                            formData.append(
+                                                "assay_type",
+                                                uploadType
+                                            );
+                                            apiCreate(
+                                                "/ingestion/intake_metadata",
+                                                token,
+                                                { data: formData }
+                                            ).then(() =>
+                                                setUploadSuccess(true)
+                                            );
+                                            e.preventDefault();
+                                        }}
+                                    >
+                                        <Grid
+                                            container
+                                            direction="column"
+                                            spacing={3}
+                                        >
+                                            <Grid item>
+                                                <FormLabel htmlFor="metadata-file">
+                                                    Metadata Spreadsheet
+                                                </FormLabel>
+                                                <FormControl fullWidth>
+                                                    <Input
+                                                        required
+                                                        id="metadata-file"
+                                                        name="xlsx"
+                                                        type="file"
+                                                    />
+                                                </FormControl>
+                                            </Grid>
+                                            <Grid item>
+                                                <FormLabel htmlFor="upload-description">
+                                                    Description of this upload
+                                                </FormLabel>
+                                                <FormControl fullWidth>
+                                                    <TextField
+                                                        required
+                                                        multiline
+                                                        name="description"
+                                                        id="upload-description"
+                                                    />
+                                                </FormControl>
+                                            </Grid>
+                                            <Grid item>
+                                                <Button
+                                                    type="submit"
+                                                    variant="contained"
+                                                    color="primary"
+                                                    disabled={uploadSuccess}
+                                                >
+                                                    {uploadSuccess
+                                                        ? "upload successful!"
+                                                        : "upload metadata"}
+                                                </Button>
+                                            </Grid>
+                                        </Grid>
+                                    </form>
+                                </Grid>
+                            </Grid>
+                        </Box>
+                        <Box pt={4}>
+                            <Typography>
+                                If you encounter any issues while attempting a
+                                data transfer, please <ContactAnAdmin lower />.
+                            </Typography>
+                        </Box>
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+});
+
+const TransferDataPage: React.FC<RouteComponentProps> = () => {
+    const classes = useRootStyles();
+    return (
+        <Grid
+            container
+            className={classes.centeredPage}
+            direction="column"
+            spacing={3}
+            alignItems="center"
+        >
+            <Grid item>
+                <TransferDataForm />
+            </Grid>
+        </Grid>
+    );
+};
+
+export default TransferDataPage;

--- a/src/components/upload-docs/UploadDocsPages.tsx
+++ b/src/components/upload-docs/UploadDocsPages.tsx
@@ -5,13 +5,18 @@ import {
     ListItem,
     ListItemText,
     Divider,
-    ListSubheader
+    ListSubheader,
+    Box,
+    Typography
 } from "@material-ui/core";
 import { map } from "lodash";
 import { RouteComponentProps, Route, withRouter, Redirect } from "react-router";
 import UploadInstructions from "./UploadInstructions";
 import { Dictionary } from "lodash";
 import PageWithSidebar from "../generic/PageWithSidebar";
+import { Alert } from "@material-ui/lab";
+import MuiRouterLink from "../generic/MuiRouterLink";
+import { widths } from "../../rootStyles";
 
 interface IDocPathConfig {
     path: string;
@@ -135,52 +140,71 @@ const UploadDocsPage: React.FunctionComponent<IUploadDocsPageProps> = props => {
     };
 
     return (
-        <PageWithSidebar
-            sidebar={
-                <Grid container>
-                    <Grid item xs={11}>
-                        <List>
-                            <DocsListItem
-                                label={"The CIDC CLI"}
-                                path={CLIInstructionsSitePath}
-                            />
-                            <ListSubheader disableSticky>
-                                {props.uploadType[0].toUpperCase() +
-                                    props.uploadType.slice(1)}
-                            </ListSubheader>
-                            {map(pathConfigs, (config, path) => {
-                                return (
-                                    config[props.uploadType] && (
-                                        <DocsListItem
-                                            key={path}
-                                            label={config.label}
-                                            path={`/${props.uploadType}/${config.path}`}
-                                        />
-                                    )
-                                );
-                            })}
-                        </List>
+        <>
+            <Box width={widths.minPageWidth} m="auto" pb={3}>
+                <Alert severity="info">
+                    <Typography>
+                        The CIDC is rolling out a new, simpler upload process,
+                        with no custom CLI required. Check out the{" "}
+                        <MuiRouterLink to="/transfer-data">
+                            Transfer Data
+                        </MuiRouterLink>{" "}
+                        page.
+                    </Typography>
+                    <Typography>
+                        If you prefer to use the CIDC CLI for uploads, it is
+                        still supported, but we recommend using the new upload
+                        process instead.
+                    </Typography>
+                </Alert>
+            </Box>
+            <PageWithSidebar
+                sidebar={
+                    <Grid container>
+                        <Grid item xs={11}>
+                            <List>
+                                <DocsListItem
+                                    label={"The CIDC CLI"}
+                                    path={CLIInstructionsSitePath}
+                                />
+                                <ListSubheader disableSticky>
+                                    {props.uploadType[0].toUpperCase() +
+                                        props.uploadType.slice(1)}
+                                </ListSubheader>
+                                {map(pathConfigs, (config, path) => {
+                                    return (
+                                        config[props.uploadType] && (
+                                            <DocsListItem
+                                                key={path}
+                                                label={config.label}
+                                                path={`/${props.uploadType}/${config.path}`}
+                                            />
+                                        )
+                                    );
+                                })}
+                            </List>
+                        </Grid>
+                        <Grid item>
+                            <Divider orientation="vertical" />
+                        </Grid>
                     </Grid>
-                    <Grid item>
-                        <Divider orientation="vertical" />
-                    </Grid>
-                </Grid>
-            }
-        >
-            <Route
-                path={`/${props.uploadType}`}
-                component={CLIRedirect}
-                exact
-            />
-            <Route
-                path={CLIInstructionsSitePath}
-                component={CLIUploadInstructions}
-            />
-            <Route
-                path={`/${props.uploadType}/:docPath`}
-                component={SelectedUploadInstructions}
-            />
-        </PageWithSidebar>
+                }
+            >
+                <Route
+                    path={`/${props.uploadType}`}
+                    component={CLIRedirect}
+                    exact
+                />
+                <Route
+                    path={CLIInstructionsSitePath}
+                    component={CLIUploadInstructions}
+                />
+                <Route
+                    path={`/${props.uploadType}/:docPath`}
+                    component={SelectedUploadInstructions}
+                />
+            </PageWithSidebar>
+        </>
     );
 };
 

--- a/src/components/upload-docs/UploadDocsPages.tsx
+++ b/src/components/upload-docs/UploadDocsPages.tsx
@@ -152,7 +152,7 @@ const UploadDocsPage: React.FunctionComponent<IUploadDocsPageProps> = props => {
                         page.
                     </Typography>
                     <Typography>
-                        If you prefer to use the CIDC CLI for uploads, it is
+                        If you prefer to use the CIDC's CLI for uploads, it is
                         still supported, but we recommend using the new upload
                         process instead.
                     </Typography>


### PR DESCRIPTION
Add a "Transfer Data" tab to the UI and an alert to the old "Transfer Assays" and "Transfer Analyses" tabs pointing users at that new tab.
<img width="1305" alt="Screen Shot 2021-01-11 at 2 52 47 PM" src="https://user-images.githubusercontent.com/14116434/104233937-b490b080-5420-11eb-9783-b31cc80647fa.png">
<img width="620" alt="Screen Shot 2021-01-11 at 3 17 31 PM" src="https://user-images.githubusercontent.com/14116434/104233943-b65a7400-5420-11eb-92a9-517874260794.png">
<img width="1305" alt="Screen Shot 2021-01-11 at 2 52 35 PM" src="https://user-images.githubusercontent.com/14116434/104234020-d1c57f00-5420-11eb-9a82-f00a750416b2.png">


