### PR TITLE
Plotly Dash proof-of-concept

### DIFF
--- a/src/components/generic/DashFrame.tsx
+++ b/src/components/generic/DashFrame.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { formatQueryString } from "../../util/formatters";
+import { withIdToken } from "../identity/AuthProvider";
+import withResize from "./withResize";
+
+export interface IDashFrameProps {
+    dashboardId: string;
+    urlParams?: Record<string, string>;
+}
+
+const makeDashboardURL = (
+    dashboardId: string,
+    params: Record<string, string>
+) => {
+    return `${
+        process.env.REACT_APP_API_URL
+    }/dashboards/${dashboardId}?${formatQueryString(params)}`;
+};
+
+const DashFrame = withIdToken<IDashFrameProps>(
+    withResize<
+        IDashFrameProps & { token: string; width?: number; height?: number }
+    >(props => {
+        return props.height && props.width ? (
+            <iframe
+                title={props.dashboardId}
+                src={makeDashboardURL(props.dashboardId, {
+                    id_token: props.token,
+                    ...props.urlParams
+                })}
+                height={props.height}
+                width={props.width}
+                frameBorder={0}
+            />
+        ) : null;
+    })
+);
+
+export default DashFrame;

--- a/src/components/profile/ProfilePage.tsx
+++ b/src/components/profile/ProfilePage.tsx
@@ -6,7 +6,8 @@ import {
     Card,
     CardHeader,
     CardContent,
-    Link
+    Link,
+    Box
 } from "@material-ui/core";
 import AdminUserManager from "./AdminUserManager";
 import { ORGANIZATION_NAME_MAP } from "../../util/constants";
@@ -18,6 +19,7 @@ import Loader from "../generic/Loader";
 import { useRootStyles } from "../../rootStyles";
 import AdminTrialManager from "./AdminTrialManager";
 import { formatDate } from "../../util/formatters";
+import DashFrame from "../generic/DashFrame";
 
 const ProfilePage: React.FC<{ token: string }> = ({ token }) => {
     const classes = useRootStyles();
@@ -153,6 +155,14 @@ const ProfilePage: React.FC<{ token: string }> = ({ token }) => {
                     </Grid>
                     <Grid item>
                         <AdminTrialManager />
+                    </Grid>
+                    <Grid item>
+                        <Typography variant="h5">
+                            Successful upload jobs (rendered by Plotly Dash)
+                        </Typography>
+                        <Box height={400}>
+                            <DashFrame dashboardId="upload_jobs" />
+                        </Box>
                     </Grid>
                 </>
             )}


### PR DESCRIPTION
Adds a simple component (`DashFrame`) for rendering auth-protected plotly dash dashboards in an iframe and displays a filterable table of successful upload jobs on the admin page using this component.