### PR TITLE
Update Transfer Data page to accommodate console urls

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@
 # Staging config
 REACT_APP_AUTH0_DOMAIN=cidc-test.auth0.com
 REACT_APP_AUTH0_CLIENT_ID=Yjlt8LT5vXFJw1Z8m8eaB5aZO26uPyeD
-REACT_APP_API_URL=https://staging-api.cimac-network.org
+REACT_APP_API_URL=http://localhost:8000
 REACT_APP_ENV=dev


### PR DESCRIPTION
UI accompaniment to https://github.com/CIMAC-CIDC/cidc-api-gae/pull/381

Adds a button for opening the user's intake bucket in the GCS web console.