### PR TITLE
Handle the new 'network-viewer' role

### DIFF
--- a/src/components/browse-data/BrowseDataPage.test.tsx
+++ b/src/components/browse-data/BrowseDataPage.test.tsx
@@ -4,8 +4,14 @@ import history from "../identity/History";
 import BrowseDataPage from "./BrowseDataPage";
 import { renderAsRouteComponent } from "../../../test/helpers";
 import { apiFetch } from "../../api/api";
+import { useUserContext } from "../identity/UserProvider";
 
 jest.mock("../../api/api");
+jest.mock("../identity/UserProvider");
+
+beforeEach(() => {
+    useUserContext.mockImplementation(() => ({ canDownload: true }));
+});
 
 test("trial view / file view toggle", async () => {
     apiFetch.mockImplementation(async (url: string) => {

--- a/src/components/browse-data/files/FileDetailsPage.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.tsx
@@ -41,11 +41,12 @@ import { Skeleton } from "@material-ui/lab";
 import { useRootStyles } from "../../../rootStyles";
 import useSWR from "swr";
 import { apiFetch } from "../../../api/api";
+import { useUserContext } from "../../identity/UserProvider";
 
 const getDownloadUrl = (token: string, fileId: number) =>
     apiFetch<string>(`/downloadable_files/download_url?id=${fileId}`, token);
 
-const DownloadURL: React.FunctionComponent<{
+const DownloadURLButton: React.FunctionComponent<{
     fileId: number;
     token: string;
 }> = ({ fileId, token }) => {
@@ -104,6 +105,8 @@ const FileHeader: React.FC<{
     file: DataFile;
     token: string;
 }> = ({ file, token }) => {
+    const user = useUserContext();
+
     const doDownload = () => {
         if (token) {
             getDownloadUrl(token, file.id).then(url => {
@@ -145,22 +148,29 @@ const FileHeader: React.FC<{
                 </Grid>
             </Grid>
             <Grid item xs={3}>
-                <Grid container direction="column" spacing={1} wrap="nowrap">
-                    <Grid item>
-                        <Button
-                            fullWidth
-                            variant="outlined"
-                            color="primary"
-                            startIcon={<CloudDownload />}
-                            onClick={() => doDownload()}
-                        >
-                            Direct Download
-                        </Button>
+                {user.canDownload && (
+                    <Grid
+                        container
+                        direction="column"
+                        spacing={1}
+                        wrap="nowrap"
+                    >
+                        <Grid item>
+                            <Button
+                                fullWidth
+                                variant="outlined"
+                                color="primary"
+                                startIcon={<CloudDownload />}
+                                onClick={() => doDownload()}
+                            >
+                                Direct Download
+                            </Button>
+                        </Grid>
+                        <Grid item>
+                            <DownloadURLButton fileId={file.id} token={token} />
+                        </Grid>
                     </Grid>
-                    <Grid item>
-                        <DownloadURL fileId={file.id} token={token} />
-                    </Grid>
-                </Grid>
+                )}
             </Grid>
         </Grid>
     );
@@ -235,6 +245,7 @@ const RelatedFiles: React.FC<{ file: DataFile; token: string }> = ({
     token,
     file
 }) => {
+    const user = useUserContext();
     const [batchDownloadOpen, setBatchDownloadOpen] = React.useState<boolean>(
         false
     );
@@ -257,15 +268,17 @@ const RelatedFiles: React.FC<{ file: DataFile; token: string }> = ({
                 </Typography>
             </Grid>
             <Grid item>
-                <Button
-                    variant="outlined"
-                    color="primary"
-                    disabled={!relatedFiles || relatedFiles.length === 0}
-                    startIcon={<CloudDownload />}
-                    onClick={() => setBatchDownloadOpen(true)}
-                >
-                    download all related files
-                </Button>
+                {user.canDownload && (
+                    <Button
+                        variant="outlined"
+                        color="primary"
+                        disabled={!relatedFiles || relatedFiles.length === 0}
+                        startIcon={<CloudDownload />}
+                        onClick={() => setBatchDownloadOpen(true)}
+                    >
+                        download all related files
+                    </Button>
+                )}
             </Grid>
         </Grid>
     );

--- a/src/components/browse-data/trials/TrialTable.tsx
+++ b/src/components/browse-data/trials/TrialTable.tsx
@@ -26,11 +26,12 @@ import { Skeleton } from "@material-ui/lab";
 import { useFilterFacets } from "../shared/FilterProvider";
 import { useSWRInfinite } from "swr";
 import { formatQueryString } from "../../../util/formatters";
+import { useUserContext } from "../../identity/UserProvider";
 
 const BatchDownloadButton: React.FC<{
     ids: number[];
     token: string;
-} & ButtonProps> = ({ ids, token, children }) => {
+} & ButtonProps> = ({ ids, token, children, disabled }) => {
     const [open, setOpen] = React.useState<boolean>(false);
     return (
         <>
@@ -39,7 +40,7 @@ const BatchDownloadButton: React.FC<{
                 size="small"
                 variant="outlined"
                 startIcon={<CloudDownload />}
-                disabled={!ids.length}
+                disabled={!ids.length || disabled}
                 onClick={() => {
                     setOpen(true);
                 }}
@@ -101,10 +102,15 @@ const AssayButton: React.FC<{
     bundle: IFileBundle[keyof IFileBundle];
     token: string;
 }> = ({ purpose, bundle, token }) => {
+    const user = useUserContext();
     const ids = bundle[purpose] || [];
     return (
         <Box m={1}>
-            <BatchDownloadButton token={token} ids={ids}>
+            <BatchDownloadButton
+                token={token}
+                ids={ids}
+                disabled={!user.canDownload}
+            >
                 {ids.length} files
             </BatchDownloadButton>
         </Box>
@@ -194,6 +200,7 @@ const LabelAndValue: React.FC<{
 };
 
 export const TrialCard: React.FC<ITrialCardProps> = ({ trial, token }) => {
+    const user = useUserContext();
     const {
         participants,
         trial_name,
@@ -267,7 +274,11 @@ export const TrialCard: React.FC<ITrialCardProps> = ({ trial, token }) => {
             <Typography variant="overline" color="textSecondary">
                 Clinical/Sample Data
             </Typography>
-            <BatchDownloadButton token={token} ids={clinicalIds}>
+            <BatchDownloadButton
+                token={token}
+                ids={clinicalIds}
+                disabled={!user.canDownload}
+            >
                 {clinicalIds.length} participant/sample files
             </BatchDownloadButton>
             {!isEmpty(assayBundle) && (

--- a/src/components/identity/UserProvider.tsx
+++ b/src/components/identity/UserProvider.tsx
@@ -13,6 +13,7 @@ export interface IAccountWithExtraContext extends Account {
     showAssays?: boolean;
     showAnalyses?: boolean;
     showManifests?: boolean;
+    canDownload?: boolean;
 }
 
 export const UserContext = React.createContext<
@@ -81,6 +82,7 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
         user?.role && ["nci-biobank-user", "cidc-admin"].includes(user.role);
     const showAnalyses =
         user?.role && ["cidc-biofx-user", "cidc-admin"].includes(user.role);
+    const canDownload = user?.role !== "network-viewer";
 
     const value =
         authData.state === "logged-in" && user && permissions
@@ -90,7 +92,8 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
                   permissions: permissions._items,
                   showAssays,
                   showManifests,
-                  showAnalyses
+                  showAnalyses,
+                  canDownload
               }
             : undefined;
 

--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -7,7 +7,8 @@ type Role =
     | "developer"
     | "devops"
     | "nci-biobank-user"
-    | "system";
+    | "system"
+    | "network-viewer";
 
 type Organization = "CIDC" | "DFCI" | "ICAHN" | "STANFORD" | "ANDERSON";
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -13,7 +13,8 @@ export const ROLES = [
     "cimac-user",
     "developer",
     "devops",
-    "nci-biobank-user"
+    "nci-biobank-user",
+    "network-viewer"
 ];
 
 export const DATE_OPTIONS = {


### PR DESCRIPTION
introduced in https://github.com/CIMAC-CIDC/cidc-api-gae/pull/409

Disables or removes download buttons throughout the portal for users with the `network-viewer` role.