### PR TITLE
Address DataOverviewPage feedback

### DIFF
--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -10,7 +10,8 @@ import {
     Typography,
     Card,
     CardContent,
-    withStyles
+    withStyles,
+    Chip
 } from "@material-ui/core";
 import { withIdToken } from "../identity/AuthProvider";
 import { ITrialOverview } from "../../model/trial";
@@ -19,10 +20,7 @@ import Loader from "../generic/Loader";
 import { RouteComponentProps } from "react-router";
 import { useRootStyles } from "../../rootStyles";
 import { formatFileSize } from "../../util/formatters";
-
-const friendlyAssayNames = {
-    hande: "h&e"
-};
+import { IDataOverview } from "../../api/api";
 
 const HeaderCell = withStyles({
     root: {
@@ -31,13 +29,14 @@ const HeaderCell = withStyles({
     }
 })(TableCell);
 
-export const DataOverviewTable: React.FC = withIdToken(({ token }) => {
-    const { data } = useSWR<ITrialOverview[]>([
+const DataOverviewTable: React.FC = withIdToken(({ token }) => {
+    const { data: overview } = useSWR<IDataOverview>(["/info/data_overview"]);
+    const { data: summary } = useSWR<ITrialOverview[]>([
         "/trial_metadata/summaries",
         token
     ]);
 
-    if (data === undefined) {
+    if (summary === undefined || overview === undefined) {
         return (
             <Grid container justify="center">
                 <Grid item>
@@ -47,20 +46,36 @@ export const DataOverviewTable: React.FC = withIdToken(({ token }) => {
         );
     }
 
-    if (data.length === 0) {
+    if (summary.length === 0) {
         return <Typography>No data found.</Typography>;
     }
 
-    const assays = Object.keys(data[0]).filter(
+    const assays = Object.keys(summary[0]).filter(
         k => !["trial_id", "file_size_bytes"].includes(k)
     );
 
     // List the trials with the most data first
-    const sortedData = sortBy(data, "file_size_bytes").reverse();
+    const sortedData = sortBy(summary, "file_size_bytes").reverse();
 
     return (
         <Card>
             <CardContent>
+                <Chip
+                    variant="outlined"
+                    label={
+                        <>
+                            <Typography
+                                display="inline"
+                                style={{ fontWeight: "bold" }}
+                            >
+                                Total Data Ingested:{" "}
+                            </Typography>
+                            <Typography display="inline">
+                                {formatFileSize(overview.num_bytes)}
+                            </Typography>
+                        </>
+                    }
+                />
                 <Table size="small">
                     <TableHead>
                         <TableRow>
@@ -74,11 +89,9 @@ export const DataOverviewTable: React.FC = withIdToken(({ token }) => {
                         </TableRow>
                         <TableRow>
                             <HeaderCell>Protocol ID</HeaderCell>
-                            <HeaderCell>Total Data Ingested</HeaderCell>
+                            <HeaderCell>Data Size</HeaderCell>
                             {assays.map(assay => (
-                                <HeaderCell key={assay}>
-                                    {friendlyAssayNames[assay] || assay}
-                                </HeaderCell>
+                                <HeaderCell key={assay}>{assay}</HeaderCell>
                             ))}
                         </TableRow>
                     </TableHead>

--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -105,8 +105,8 @@ describe("Header", () => {
         const { queryByText: q1 } = renderWithUserContext(user);
         checkVisibility(
             q1,
-            ["browse data", "pipelines", "schema"],
-            ["manifests", "assays", "analyses", "data overview"]
+            ["browse data", "pipelines", "schema", "data overview"],
+            ["manifests", "assays", "analyses"]
         );
         cleanup();
 
@@ -117,8 +117,8 @@ describe("Header", () => {
         });
         checkVisibility(
             q2,
-            ["browse data", "pipelines", "schema", "assays"],
-            ["manifests", "analyses", "data overview"]
+            ["browse data", "pipelines", "schema", "assays", "data overview"],
+            ["manifests", "analyses"]
         );
         cleanup();
 
@@ -148,8 +148,15 @@ describe("Header", () => {
         });
         checkVisibility(
             q4,
-            ["browse data", "pipelines", "schema", "assays", "analyses"],
-            ["manifests", "data overview"]
+            [
+                "browse data",
+                "pipelines",
+                "schema",
+                "assays",
+                "analyses",
+                "data overview"
+            ],
+            ["manifests"]
         );
         cleanup();
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -303,7 +303,7 @@ const Header: React.FunctionComponent<RouteComponentProps> = props => {
                                             value: "/pipelines"
                                         },
                                         { label: "schema", value: "/schema" },
-                                        user.showManifests && {
+                                        {
                                             label: "data overview",
                                             value: "/data-overview"
                                         }


### PR DESCRIPTION
* Show the data overview tab to all logged-in users
* Include total CIDC data size above data overview table
* Don't transform assay names on the frontend (this happens on the backed now)