### PR TITLE
Update TrialTable to handle API changes

### DIFF
--- a/src/model/trial.ts
+++ b/src/model/trial.ts
@@ -7,6 +7,8 @@ export interface Trial {
     trial_id: string;
     metadata_json: any;
     file_bundle?: IFileBundle;
+    num_participants?: number;
+    num_samples?: number;
     // TODO: implement role-based access to Trial resources in the new API.
     // TODO: add missing fields (e.g., assays, participants) to this object.
 }


### PR DESCRIPTION
UI accompaniment to https://github.com/CIMAC-CIDC/cidc-api-gae/pull/439

Also, modify `TrialCard`'s behavior for trials with no files: instead of rendering nothing, display a trial card with a note saying that no files have been uploaded to the trial.
