### PR TITLE
URI-encode facet filters

### DIFF
--- a/src/components/browse-data/files/FileTable.test.tsx
+++ b/src/components/browse-data/files/FileTable.test.tsx
@@ -20,11 +20,11 @@ test("filterParams", () => {
     expect(filterParams({})).toEqual({});
     const exampleFilters = {
         trial_ids: ["a", "b"],
-        facets: ["foo|a|1", "foo|a|2", "bar|1", "bar|2"]
+        facets: ["foo|h&e|1", "foo|a|2", "bar|1", "bar|2"]
     };
     expect(filterParams(exampleFilters)).toEqual({
-        trial_ids: "a,b",
-        facets: "foo|a|1,foo|a|2,bar|1,bar|2"
+        trial_ids: "a%2Cb",
+        facets: "foo%7Ch%26e%7C1%2Cfoo%7Ca%7C2%2Cbar%7C1%2Cbar%7C2"
     });
 });
 

--- a/src/components/browse-data/files/FileTable.tsx
+++ b/src/components/browse-data/files/FileTable.tsx
@@ -63,7 +63,11 @@ export interface IFileTableProps {
 
 export const filterParams = (filters: IFilters) => {
     const joinParam = (ps?: string[]) =>
-        ps ? (ps.length > 0 ? ps.join(",") : undefined) : undefined;
+        ps
+            ? ps.length > 0
+                ? encodeURIComponent(ps.join(","))
+                : undefined
+            : undefined;
     return {
         trial_ids: joinParam(filters.trial_ids),
         facets: joinParam(filters.facets)

--- a/src/components/browse-data/trials/TrialTable.test.tsx
+++ b/src/components/browse-data/trials/TrialTable.test.tsx
@@ -178,7 +178,7 @@ it("handles pagination as expected", async () => {
 
 it("filters by trial id", async () => {
     apiFetch.mockImplementation(async url => {
-        expect(url).toContain("trial_ids=test-trial-0,test-trial-1");
+        expect(url).toContain("trial_ids=test-trial-0%2Ctest-trial-1");
         return { ...trialsPageOne, _items: trialsPageOne._items.slice(0, 2) };
     });
     const { findByText, queryByText } = renderWithRouter(

--- a/src/components/browse-data/trials/TrialTable.tsx
+++ b/src/components/browse-data/trials/TrialTable.tsx
@@ -348,7 +348,9 @@ export const usePaginatedTrials = (token: string) => {
                 include_counts: true,
                 page_size: TRIALS_PER_PAGE,
                 page_num: pageIndex,
-                trial_ids: filters.trial_ids?.join(",")
+                trial_ids: filters.trial_ids
+                    ? encodeURIComponent(filters.trial_ids.join(","))
+                    : undefined
             })}`,
             token
         ];


### PR DESCRIPTION
This fixes a current bug where selecting the `H&E` facet breaks filtering in the file browser and guards against future similar bugs.