### PR TITLE
Handle clinical and sample-tracking files separately

### DIFF
--- a/src/components/browse-data/files/FileDetailsPage.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.tsx
@@ -34,7 +34,7 @@ import {
     formatDataCategory,
     formatDate,
     formatFileSize
-} from "../../../util/formatters";
+} from "../../../util/utils";
 import { isEmpty, map, range, sortBy } from "lodash";
 import BatchDownloadDialog from "../shared/BatchDownloadDialog";
 import { Skeleton } from "@material-ui/lab";

--- a/src/components/browse-data/files/FileTable.tsx
+++ b/src/components/browse-data/files/FileTable.tsx
@@ -21,7 +21,7 @@ import {
     formatDate,
     formatFileSize,
     formatQueryString
-} from "../../../util/formatters";
+} from "../../../util/utils";
 import { useHistory } from "react-router-dom";
 import useSWR from "swr";
 import { useUserContext } from "../../identity/UserProvider";

--- a/src/components/browse-data/shared/FilterProvider.tsx
+++ b/src/components/browse-data/shared/FilterProvider.tsx
@@ -4,7 +4,7 @@ import { ArrayParam, useQueryParams } from "use-query-params";
 import { withIdToken } from "../../identity/AuthProvider";
 import { filterParams } from "../files/FileTable";
 import useSWR from "swr";
-import { formatQueryString } from "../../../util/formatters";
+import { formatQueryString } from "../../../util/utils";
 
 export interface IFacetInfo {
     label: string;

--- a/src/components/browse-data/trials/TrialTable.test.tsx
+++ b/src/components/browse-data/trials/TrialTable.test.tsx
@@ -33,6 +33,9 @@ const fileBundle = {
     "Samples Info": {
         clinical: [12]
     },
+    "Clinical Data": {
+        clinical: [13]
+    },
     other: {
         source: [1, 2, 3]
     }
@@ -110,9 +113,11 @@ it("renders trials with no filters applied", async () => {
     expect(queryAllByText(new RegExp("nice biobank", "i")).length).toBe(10);
 
     // renders batch download interface
-    const clinicalButtons = queryAllByText(/2 participant\/sample files/i);
+    const partSampButtons = queryAllByText(/2 participant\/sample files/i);
+    const clinicalButtons = queryAllByText(/1 clinical data file/i);
     const fourFileButtons = queryAllByText(/4 files/i);
     const zeroFileButtons = queryAllByText(/0 files/i);
+    expect(partSampButtons.length).toBe(10);
     expect(clinicalButtons.length).toBe(10);
     expect(queryAllByText(/cytof/i).length).toBe(10);
     expect(fourFileButtons.length).toBe(10);
@@ -122,6 +127,7 @@ it("renders trials with no filters applied", async () => {
     expect(zeroFileButtons.length).toBe(10);
 
     // buttons with files available are enabled
+    expect(partSampButtons[0].closest("button").disabled).toBe(false);
     expect(clinicalButtons[0].closest("button").disabled).toBe(false);
     expect(fourFileButtons[0].closest("button").disabled).toBe(false);
     expect(zeroFileButtons[0].closest("button").disabled).toBe(true);
@@ -133,11 +139,13 @@ it("doesn't enable download buttons if users don't have download permission", as
     const { findByText, queryAllByText } = renderTrialTable();
 
     expect(await findByText(/test-trial-0/i)).toBeInTheDocument();
-    const clinicalButtons = queryAllByText(/2 participant\/sample files/i);
+    const partSampButtons = queryAllByText(/2 participant\/sample files/i);
+    const clinicalButtons = queryAllByText(/1 clinical data file/i);
     const fourFileButtons = queryAllByText(/4 files/i);
     const zeroFileButtons = queryAllByText(/0 files/i);
 
     // All download buttons are disabled
+    expect(partSampButtons[0].closest("button").disabled).toBe(true);
     expect(clinicalButtons[0].closest("button").disabled).toBe(true);
     expect(fourFileButtons[0].closest("button").disabled).toBe(true);
     expect(zeroFileButtons[0].closest("button").disabled).toBe(true);

--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -19,7 +19,7 @@ import useSWR from "swr";
 import Loader from "../generic/Loader";
 import { RouteComponentProps } from "react-router";
 import { useRootStyles } from "../../rootStyles";
-import { formatFileSize } from "../../util/formatters";
+import { formatFileSize } from "../../util/utils";
 import { IDataOverview } from "../../api/api";
 
 const HeaderCell = withStyles({

--- a/src/components/generic/DashFrame.tsx
+++ b/src/components/generic/DashFrame.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatQueryString } from "../../util/formatters";
+import { formatQueryString } from "../../util/utils";
 import { withIdToken } from "../identity/AuthProvider";
 import withResize from "./withResize";
 

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -22,7 +22,7 @@ import { RouteComponentProps } from "react-router-dom";
 import pactLogo from "../../pact_logo.svg";
 import fnihLogo from "../../fnih_logo.svg";
 import nciLogo from "../../nci_logo.svg";
-import { formatFileSize } from "../../util/formatters";
+import { formatFileSize } from "../../util/utils";
 import FadeInOnMount from "../generic/FadeInOnMount";
 import { Alert } from "@material-ui/lab";
 import ContactAnAdmin from "../generic/ContactAnAdmin";

--- a/src/components/profile/AdminUserManager.tsx
+++ b/src/components/profile/AdminUserManager.tsx
@@ -27,7 +27,7 @@ import { ORGANIZATION_NAME_MAP, ROLES } from "../../util/constants";
 import UserPermissionsDialogWithInfo from "./AdminUserPermissionsDialog";
 import { useForm } from "react-hook-form";
 import useSWR from "swr";
-import { formatQueryString } from "../../util/formatters";
+import { formatQueryString } from "../../util/utils";
 import { apiUpdate } from "../../api/api";
 import moment from "moment";
 import Loader from "../generic/Loader";

--- a/src/components/profile/ProfilePage.tsx
+++ b/src/components/profile/ProfilePage.tsx
@@ -18,7 +18,7 @@ import { AccountCircle, FolderShared } from "@material-ui/icons";
 import Loader from "../generic/Loader";
 import { useRootStyles } from "../../rootStyles";
 import AdminTrialManager from "./AdminTrialManager";
-import { formatDate } from "../../util/formatters";
+import { formatDate } from "../../util/utils";
 import DashFrame from "../generic/DashFrame";
 
 const ProfilePage: React.FC<{ token: string }> = ({ token }) => {

--- a/src/util/formatters.test.ts
+++ b/src/util/formatters.test.ts
@@ -1,8 +1,0 @@
-import { formatDataCategory } from "./formatters";
-
-test("formatDataCategory", () => {
-    expect(formatDataCategory("Foo|Bar")).toBe("Foo Bar");
-    expect(formatDataCategory("Foo|")).toBe("Foo");
-    expect(formatDataCategory("Foo")).toBe("Foo");
-    expect(formatDataCategory("")).toBe("");
-});

--- a/src/util/utils.test.ts
+++ b/src/util/utils.test.ts
@@ -1,0 +1,16 @@
+import { formatDataCategory, naivePluralize } from "./utils";
+
+test("formatDataCategory", () => {
+    expect(formatDataCategory("Foo|Bar")).toBe("Foo Bar");
+    expect(formatDataCategory("Foo|")).toBe("Foo");
+    expect(formatDataCategory("Foo")).toBe("Foo");
+    expect(formatDataCategory("")).toBe("");
+});
+
+test("naivePluralize", () => {
+    const word = "word";
+    const words = "words";
+    expect(naivePluralize(word, 0)).toBe(words);
+    expect(naivePluralize(word, 1)).toBe(word);
+    expect(naivePluralize(word, 2)).toBe(words);
+});

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -29,3 +29,7 @@ export const formatQueryString = (
         ""
     );
 };
+
+export const naivePluralize = (str: string, n: number) => {
+    return n !== 1 ? str + "s" : str;
+};


### PR DESCRIPTION
Also, make `TrialCard`s smarter about pluralizing the word "files".