### PR TITLE
Update BatchDownloadDialog to support direct downloads of small batches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,13 @@ export default function App() {
 
     return (
         <Router history={history}>
-            <SWRConfig value={{ fetcher: apiFetch, shouldRetryOnError: false }}>
+            <SWRConfig
+                value={{
+                    fetcher: apiFetch,
+                    shouldRetryOnError: false,
+                    revalidateOnFocus: false
+                }}
+            >
                 <QueryParamProvider ReactRouterRoute={Route}>
                     <div className={classes.root}>
                         <CIDCThemeProvider>

--- a/src/components/browse-data/shared/BatchDownloadDialog.test.tsx
+++ b/src/components/browse-data/shared/BatchDownloadDialog.test.tsx
@@ -29,20 +29,25 @@ it("shows expected errors on direct download click", async () => {
         <BatchDownloadDialog ids={ids} token={"foo"} open />
     );
 
+    const directDownloadButton = getByText(/download directly/i).closest(
+        "button"
+    )!;
+
     // Check a "no files available" error
     apiCreate.mockRejectedValue({ response: { status: 404 } });
-    fireEvent.click(getByText(/download directly/i));
+    fireEvent.click(directDownloadButton);
     expect(await findByText(/you don't have permission/i)).toBeInTheDocument();
-
-    // Check a "batch too large" error
-    apiCreate.mockRejectedValue({ response: { status: 400 } });
-    fireEvent.click(getByText(/download directly/i));
-    expect(await findByText(/more than 100MB/i)).toBeInTheDocument();
 
     // Check a miscellaneous error
     apiCreate.mockRejectedValue({ response: { status: 500 } });
-    fireEvent.click(getByText(/download directly/i));
+    fireEvent.click(directDownloadButton);
     expect(await findByText(/unexpected issue/i)).toBeInTheDocument();
+
+    // Check a "batch too large" error
+    apiCreate.mockRejectedValue({ response: { status: 400 } });
+    fireEvent.click(directDownloadButton);
+    expect(await findByText(/more than 100MB/i)).toBeInTheDocument();
+    expect(directDownloadButton.disabled).toBe(true);
 });
 
 it("shows an info message when a direct download is loading", async () => {

--- a/src/components/browse-data/shared/BatchDownloadDialog.test.tsx
+++ b/src/components/browse-data/shared/BatchDownloadDialog.test.tsx
@@ -6,17 +6,61 @@ import BatchDownloadDialog from "./BatchDownloadDialog";
 
 jest.mock("../../../api/api");
 
-it("shows an error when users don't have download permissions", async () => {
-    apiCreate.mockRejectedValue({ response: { status: 404 } });
-
+it("shows expected errors on filelist download click", async () => {
     const ids = [1, 2, 3];
     const { getByText, findByText } = renderWithUserContext(
         <BatchDownloadDialog ids={ids} token={"foo"} open />
     );
 
-    // Click the download button
+    // Check a "no files available" error
+    apiCreate.mockRejectedValue({ response: { status: 404 } });
     fireEvent.click(getByText(/download filelist/i));
-
-    // Check that an error is displayed
     expect(await findByText(/you don't have permission/i)).toBeInTheDocument();
+
+    // Check a miscellaneous error
+    apiCreate.mockRejectedValue({ response: { status: 500 } });
+    fireEvent.click(getByText(/download filelist/i));
+    expect(await findByText(/unexpected issue/i)).toBeInTheDocument();
+});
+
+it("shows expected errors on direct download click", async () => {
+    const ids = [1, 2, 3];
+    const { getByText, findByText } = renderWithUserContext(
+        <BatchDownloadDialog ids={ids} token={"foo"} open />
+    );
+
+    // Check a "no files available" error
+    apiCreate.mockRejectedValue({ response: { status: 404 } });
+    fireEvent.click(getByText(/download directly/i));
+    expect(await findByText(/you don't have permission/i)).toBeInTheDocument();
+
+    // Check a "batch too large" error
+    apiCreate.mockRejectedValue({ response: { status: 400 } });
+    fireEvent.click(getByText(/download directly/i));
+    expect(await findByText(/more than 100MB/i)).toBeInTheDocument();
+
+    // Check a miscellaneous error
+    apiCreate.mockRejectedValue({ response: { status: 500 } });
+    fireEvent.click(getByText(/download directly/i));
+    expect(await findByText(/unexpected issue/i)).toBeInTheDocument();
+});
+
+it("shows an info message when a direct download is loading", async () => {
+    apiCreate.mockImplementation(() => {
+        // Sleep for 5 seconds
+        return new Promise(resolve => setTimeout(() => resolve, 5000));
+    });
+    const ids = [1, 2, 3];
+    const { getByText, findByText } = renderWithUserContext(
+        <BatchDownloadDialog ids={ids} token={"foo"} open />
+    );
+
+    const directDownloadButton = getByText(/download directly/i).closest(
+        "button"
+    )!;
+    fireEvent.click(directDownloadButton);
+    expect(
+        await findByText(/creating a compressed archive/i)
+    ).toBeInTheDocument();
+    expect(directDownloadButton.disabled).toBe(true);
 });

--- a/src/components/browse-data/shared/BatchDownloadDialog.tsx
+++ b/src/components/browse-data/shared/BatchDownloadDialog.tsx
@@ -1,10 +1,14 @@
 import {
+    Box,
     Button,
     Dialog,
     DialogActions,
     DialogContent,
     DialogTitle,
-    Grid
+    Divider,
+    Grid,
+    LinearProgress,
+    Typography
 } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 import React from "react";
@@ -18,6 +22,14 @@ export interface IBatchDownloadDialogProps {
     onClose?: () => void;
 }
 
+const errors = {
+    NO_PERMS:
+        "You don't have permission to download the files in this batch. Please contact cidc@jimmy.harvard.edu if you believe this is a mistake.",
+    TOO_BIG:
+        "This file batch is more than 100MB and cannot be downloaded directly.",
+    UNKNOWN: "Encountered an unexpected issue with this download."
+};
+
 const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
     ids,
     token,
@@ -25,6 +37,28 @@ const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
     onClose
 }) => {
     const [error, setError] = React.useState<string>("");
+    const [loadingDownload, setLoadingDownload] = React.useState<boolean>(
+        false
+    );
+
+    const downloadDirectly = () => {
+        setLoadingDownload(true);
+        apiCreate<string>("/downloadable_files/compressed_batch", token, {
+            data: { file_ids: ids }
+        })
+            .then(url => window.location.assign(url))
+            .catch(err => {
+                const status = err.response?.status;
+                if (status === 404) {
+                    setError(errors.NO_PERMS);
+                } else if (status === 400) {
+                    setError(errors.TOO_BIG);
+                } else {
+                    setError(errors.UNKNOWN);
+                }
+            })
+            .finally(() => setLoadingDownload(false));
+    };
 
     const downloadFilelist = () => {
         apiCreate<string>("/downloadable_files/filelist", token, {
@@ -43,16 +77,24 @@ const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
                 URL.revokeObjectURL(url);
             })
             .catch(err => {
-                if (err.response.status) {
-                    setError(
-                        "You don't have permission to download the files in this batch. Please contact cidc@jimmy.harvard.edu if you believe this is a mistake."
-                    );
+                if (err.response?.status === 404) {
+                    setError(errors.NO_PERMS);
+                } else {
+                    setError(errors.UNKNOWN);
                 }
             });
     };
 
     return (
-        <Dialog open={!!open} onClose={onClose}>
+        <Dialog
+            open={!!open}
+            onClose={() => {
+                setError("");
+                if (onClose) {
+                    onClose();
+                }
+            }}
+        >
             <DialogTitle>
                 Batch download{" "}
                 <strong>
@@ -60,40 +102,88 @@ const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
                 </strong>
             </DialogTitle>
             <DialogContent>
-                <CIDCMarkdown
-                    source={[
-                        'Download the "filelist.tsv" file for this file batch,' +
-                            "and run this command in the desired download directory:",
-                        "```bash",
-                        "cat filelist.tsv | xargs -n 2 -P 8 gsutil cp",
-                        "```",
-                        "If you haven't logged in with `gcloud` recently, you'll " +
-                            "need to run `gcloud auth login` first.",
-                        "",
-                        "This command requires a [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install) " +
-                            "installation and a shell that supports `cat` and `xargs`.",
-                        "",
-                        "Note: Batch downloads are resumable. If you cancel an ongoing download (e.g., " +
-                            "using control+c), you can resume that download by rerunning the download command."
-                    ].join("\n")}
-                />
-                {error && <Alert severity="error">{error}</Alert>}
-            </DialogContent>
-            <DialogActions>
-                <Grid container justify="space-between">
+                <Grid
+                    container
+                    direction="column"
+                    alignItems="stretch"
+                    spacing={1}
+                >
                     <Grid item>
-                        <Button onClick={onClose}>Cancel</Button>
+                        <Grid
+                            container
+                            justify="space-between"
+                            alignItems="center"
+                        >
+                            <Grid item xs={5}>
+                                <Button
+                                    fullWidth
+                                    color="primary"
+                                    variant="contained"
+                                    disabled={loadingDownload}
+                                    onClick={() => downloadDirectly()}
+                                >
+                                    download directly
+                                </Button>
+                            </Grid>
+                            <Grid item xs={2}>
+                                <Typography
+                                    style={{
+                                        width: "100%",
+                                        fontSize: "1rem",
+                                        textAlign: "center"
+                                    }}
+                                    display="block"
+                                    variant="overline"
+                                >
+                                    OR
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={5}>
+                                <Button
+                                    fullWidth
+                                    color="primary"
+                                    variant="contained"
+                                    onClick={() => downloadFilelist()}
+                                >
+                                    download filelist.tsv
+                                </Button>
+                            </Grid>
+                        </Grid>
                     </Grid>
                     <Grid item>
-                        <Button
-                            color="primary"
-                            variant="contained"
-                            onClick={() => downloadFilelist()}
-                        >
-                            Download Filelist.tsv
-                        </Button>
+                        {loadingDownload && (
+                            <Alert severity="info">
+                                Creating a compressed archive of this file batch
+                                (this may take a while).{" "}
+                                <LinearProgress variant="indeterminate" />
+                            </Alert>
+                        )}
+                        {error && <Alert severity="error">{error}</Alert>}
+                        <Box paddingTop={1}>
+                            <Divider />
+                        </Box>
+                    </Grid>
+                    <Grid item>
+                        <CIDCMarkdown
+                            source={[
+                                "Batches larger than 100MB must be downloaded via [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install). " +
+                                    'Download the "filelist.tsv" file for this file batch,' +
+                                    "and run this command in the desired download directory:",
+                                "```bash",
+                                "cat filelist.tsv | xargs -n 2 -P 8 gsutil cp",
+                                "```",
+                                "If you haven't logged in with `gcloud` recently, you'll " +
+                                    "need to run `gcloud auth login` first.",
+                                "",
+                                "Note: Batch downloads are resumable. If you cancel an ongoing download (e.g., " +
+                                    "using control+c), you can resume that download by rerunning the download command."
+                            ].join("\n")}
+                        />
                     </Grid>
                 </Grid>
+            </DialogContent>
+            <DialogActions>
+                {/* placeholder that adds some padding */}
             </DialogActions>
         </Dialog>
     );

--- a/src/components/browse-data/shared/BatchDownloadDialog.tsx
+++ b/src/components/browse-data/shared/BatchDownloadDialog.tsx
@@ -119,7 +119,10 @@ const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
                                     fullWidth
                                     color="primary"
                                     variant="contained"
-                                    disabled={loadingDownload}
+                                    disabled={
+                                        loadingDownload ||
+                                        error === errors.TOO_BIG
+                                    }
                                     onClick={() => downloadDirectly()}
                                 >
                                     download directly


### PR DESCRIPTION
Initial view:
<img width="633" alt="Screen Shot 2021-04-29 at 4 40 00 PM" src="https://user-images.githubusercontent.com/14116434/116615617-92586b00-a909-11eb-8816-141d42b44d7e.png">
Loading view:
<img width="688" alt="Screen Shot 2021-04-29 at 4 11 25 PM" src="https://user-images.githubusercontent.com/14116434/116615575-8076c800-a909-11eb-9d15-e660779506e5.png">
Error view:
<img width="632" alt="Screen Shot 2021-04-29 at 4 13 16 PM" src="https://user-images.githubusercontent.com/14116434/116615560-781e8d00-a909-11eb-886b-04e321b95c04.png">
