### PR TITLE
Add support for trial expected assays

### DIFF
--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -18,7 +18,7 @@ import { ITrialOverview } from "../../model/trial";
 import useSWR from "swr";
 import Loader from "../generic/Loader";
 import { RouteComponentProps } from "react-router";
-import { useRootStyles } from "../../rootStyles";
+import { theme, useRootStyles } from "../../rootStyles";
 import { formatFileSize } from "../../util/utils";
 import { IDataOverview } from "../../api/api";
 
@@ -29,14 +29,69 @@ const HeaderCell = withStyles({
     }
 })(TableCell);
 
+const NoAssayCell = withStyles({
+    root: {
+        background: theme.palette.grey[200]
+    }
+})(TableCell);
+
 const nonAssayFields = [
     "trial_id",
     "expected_assays",
     "file_size_bytes",
+    "expected_assays",
     "clinical_participants",
     "total_participants",
     "total_samples"
 ];
+
+const DataOverviewRow: React.FC<{
+    overview: ITrialOverview;
+    assays: string[];
+}> = ({ overview, assays }) => {
+    return (
+        <TableRow>
+            <TableCell>{overview.trial_id}</TableCell>
+            <TableCell align="right">
+                {formatFileSize(overview.file_size_bytes)}
+            </TableCell>
+            <TableCell align="right">
+                <Chip
+                    style={{ width: "100%" }}
+                    color={
+                        overview.clinical_participants > 0
+                            ? "primary"
+                            : "default"
+                    }
+                    variant="outlined"
+                    label={`${overview.clinical_participants} / ${overview.total_participants} participants`}
+                />
+            </TableCell>
+            {assays.map(assay =>
+                overview.expected_assays.includes(assay) ||
+                overview[assay] > 0 ? (
+                    <TableCell
+                        key={assay}
+                        align="center"
+                        data-testid={`data-${overview.trial_id}-${assay}`}
+                    >
+                        {overview[assay]}
+                    </TableCell>
+                ) : (
+                    <NoAssayCell
+                        key={assay}
+                        align="center"
+                        data-testid={`na-${overview.trial_id}-${assay}`}
+                    >
+                        <Typography color="textSecondary" variant="caption">
+                            n/a
+                        </Typography>
+                    </NoAssayCell>
+                )
+            )}
+        </TableRow>
+    );
+};
 
 const DataOverviewTable: React.FC = withIdToken(({ token }) => {
     const { data: overview } = useSWR<IDataOverview>(["/info/data_overview"]);
@@ -112,29 +167,11 @@ const DataOverviewTable: React.FC = withIdToken(({ token }) => {
                     </TableHead>
                     <TableBody>
                         {sortedData.map(row => (
-                            <TableRow key={row.trial_id}>
-                                <TableCell>{row.trial_id}</TableCell>
-                                <TableCell align="right">
-                                    {formatFileSize(row.file_size_bytes)}
-                                </TableCell>
-                                <TableCell align="right">
-                                    <Chip
-                                        style={{ width: "100%" }}
-                                        color={
-                                            row.clinical_participants > 0
-                                                ? "primary"
-                                                : "default"
-                                        }
-                                        variant="outlined"
-                                        label={`${row.clinical_participants} / ${row.total_participants} participants`}
-                                    />
-                                </TableCell>
-                                {assays.map(assay => (
-                                    <TableCell key={assay} align="right">
-                                        {row[assay] || "-"}
-                                    </TableCell>
-                                ))}
-                            </TableRow>
+                            <DataOverviewRow
+                                key={row.trial_id}
+                                overview={row}
+                                assays={assays}
+                            />
                         ))}
                     </TableBody>
                 </Table>

--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -127,6 +127,9 @@ const DataOverviewTable: React.FC = withIdToken(({ token }) => {
     return (
         <Card>
             <CardContent>
+                <Typography variant="subtitle2" align="right">
+                    n/a = assay not expected for this trial
+                </Typography>
                 <Chip
                     variant="outlined"
                     label={

--- a/src/components/profile/AdminTrialManager.tsx
+++ b/src/components/profile/AdminTrialManager.tsx
@@ -18,7 +18,8 @@ import {
     Radio,
     FormControlLabel,
     GridProps,
-    AccordionActions
+    AccordionActions,
+    Checkbox
 } from "@material-ui/core";
 import { LibraryAdd, Add, ExpandMore } from "@material-ui/icons";
 import { withIdToken } from "../identity/AuthProvider";
@@ -28,10 +29,11 @@ import {
     useForm,
     useFormContext
 } from "react-hook-form";
-import { mapValues, omit, omitBy, range } from "lodash";
+import { mapValues, omit, omitBy, range, uniq } from "lodash";
 import { Skeleton } from "@material-ui/lab";
 import useSWR from "swr";
 import { apiCreate, apiUpdate, apiFetch, IApiPage } from "../../api/api";
+import { useInfoContext } from "../info/InfoProvider";
 
 const TrialTextField: React.FC<{
     name: string;
@@ -78,6 +80,53 @@ const TrialStatusField: React.FC<{ width: GridProps["xs"] }> = ({ width }) => {
                     name={name}
                     control={control}
                 />
+            </FormControl>
+        </Grid>
+    );
+};
+
+const TrialExpectAssaysField: React.FC<{ width: GridProps["xs"] }> = ({
+    width
+}) => {
+    const { register, getValues } = useFormContext();
+    const name = "expected_assays";
+    const checked: string[] = getValues()[name] || [];
+
+    const {
+        supportedTemplates: { assays }
+    } = useInfoContext();
+
+    // Hacky way to ensure wes_bam and wes_fastq show up like "wes"
+    // cytof_10021 and cytof_e4412 show up like "cytof", "hande" as
+    // "h&e", etc.
+    const simplifiedAssays = uniq(
+        assays.map(a => {
+            if (a === "hande") {
+                return "h&e";
+            }
+            return a.split("_")[0];
+        })
+    );
+
+    return (
+        <Grid item xs={width}>
+            <FormControl component="fieldset">
+                <FormLabel component="legend">Expected Assays</FormLabel>
+                <Grid container spacing={1}>
+                    {simplifiedAssays.map(v => (
+                        <Grid item key={v}>
+                            <FormControlLabel
+                                key={v}
+                                label={v}
+                                value={v}
+                                name={name}
+                                inputRef={register}
+                                defaultChecked={checked.includes(v)}
+                                control={<Checkbox size="small" />}
+                            />
+                        </Grid>
+                    ))}
+                </Grid>
             </FormControl>
         </Grid>
     );
@@ -151,6 +200,7 @@ const TrialAccordion = withIdToken<{
                     </AccordionSummary>
                     <AccordionDetails>
                         <Grid container spacing={1}>
+                            <TrialExpectAssaysField width={12} />
                             <TrialTextField
                                 name="allowed_cohort_names"
                                 label="Cohort Names (comma-separated)"

--- a/src/components/profile/AdminTrialManager.tsx
+++ b/src/components/profile/AdminTrialManager.tsx
@@ -121,8 +121,12 @@ const TrialExpectAssaysField: React.FC<{ width: GridProps["xs"] }> = ({
                                 value={v}
                                 name={name}
                                 inputRef={register}
-                                defaultChecked={checked.includes(v)}
-                                control={<Checkbox size="small" />}
+                                control={
+                                    <Checkbox
+                                        size="small"
+                                        defaultChecked={checked.includes(v)}
+                                    />
+                                }
                             />
                         </Grid>
                     ))}

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -161,6 +161,7 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                         align="center"
                                     >
                                         <Grid
+                                            container
                                             direction="row"
                                             alignItems="center"
                                         >

--- a/src/model/trial.ts
+++ b/src/model/trial.ts
@@ -26,9 +26,10 @@ export interface IFileBundle {
 
 export interface ITrialOverview {
     trial_id: string;
+    expected_assays: string[];
     file_size_bytes: number;
     clinical_participants: number;
     total_participants: number;
     total_samples: number;
-    [assay: string]: number | string;
+    [assay: string]: number | string | string[];
 }


### PR DESCRIPTION
This PR:
* adds an array of assay checkboxes to the admin interface for designating expected assays for a trial
* visually distinguishes between expected assays with no data and not-applicable assays on the data overview page