### PR TITLE
CIDC-1118 add ATACseq to assays with analysis

### DIFF
--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -35,7 +35,14 @@ const NONASSAY_FIELDS = [
     "excluded_samples"
 ];
 
-const ASSAYS_WITH_ANALYSIS = ["wes", "rna", "tcr", "cytof", "wes_tumor_only"];
+const ASSAYS_WITH_ANALYSIS = [
+    "atacseq",
+    "cytof",
+    "rna",
+    "tcr",
+    "wes",
+    "wes_tumor_only"
+];
 
 const HeaderCell = withStyles({
     root: {


### PR DESCRIPTION
## What

Add ATACseq `atacseq` to the constant `ASSAYS_WITH_ANALYSIS` in the Data Overview.

## Why

Closes [CIDC-1118](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1118).

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - All new code has been type annotated in the function signatures using type hints
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - Documentation in [`docs/`](https://github.com/CIMAC-CIDC/cidc-schemas/tree/master/docs) has be regenerated and README has been updated to explain major changes & new features