### PR TITLE
CIDC-1047 CIDC-1054 Dashboard updates: WES counting, links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## What
+
+Describe very concisely what this Pull Request does.
+
+## Why
+
+Describe what motivated this Pull Request and why this was necessary. Link to the relevant JIRA Issue. Ex. Closes CIDC-1086
+
+## How
+
+Describe details of how you implemented the solution, outlining the major steps involved in adding this new feature or fixing this bug. Provide code-snippets if possible, showing example usage.
+
+## Remarks
+
+Add notes on possible known quirks/drawbacks of this solution.
+
+## Checklist
+
+Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:
+
+- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
+- [ ] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
+- [ ] Docstrings - Docstrings have been provided for functions
+- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+This Changelog tracks changes to this project. The notes below include a summary for each release, followed by details which contain one or more of the following tags:
+
+- `added` for new features.
+- `changed` for functionality and API changes.
+- `deprecated` for soon-to-be removed features.
+- `removed` for now removed features.
+- `fixed` for any bug fixes.
+- `security` in case of vulnerabilities.
+
+## 19 May 2022
+
+- `changed` WES display on data-overview to compensate for the changes in counting in the API
+  - `changed` "wes" -> "wes_normal" and "wes_tumor_only" -> "wes_tumor"
+- `added` links from data-overview to browse-data, with appropriate trial_id and facet params
+  - uses new /downloable_files/facet_groups_for_links in the API which was added for this purpose

--- a/src/components/data-overview/DataOverviewPage.test.tsx
+++ b/src/components/data-overview/DataOverviewPage.test.tsx
@@ -25,6 +25,43 @@ it("displays data as expected", async () => {
         switch (url) {
             case "/info/data_overview":
                 return { num_bytes: 1e9 };
+            case "/downloadable_files/facet_groups_for_links":
+                return {
+                    facets: {
+                        atacseq: {
+                            // test multiple values as well as space
+                            received: ["atacseq_assay", "atacseq assay"],
+                            analyzed: ["atacseq_analysis"]
+                        },
+                        cytof: {
+                            received: ["cytof_assay"],
+                            analyzed: ["cytof_analysis"]
+                        },
+                        elisa: { received: ["elisa_assay"] },
+                        // test special character
+                        "h&e": { received: ["h&e_assay"] },
+                        ihc: { received: ["ihc_assay"] },
+                        mif: { received: ["mif_assay"] },
+                        nanostring: { received: ["mif_assay"] },
+                        olink: { received: ["olink_assay"] },
+                        rna: {
+                            received: ["rna_assay"],
+                            analyzed: ["rna_analysis"]
+                        },
+                        tcr: {
+                            received: ["tcr_assay"],
+                            analyzed: ["tcr_analysis"]
+                        },
+                        wes_normal: {
+                            received: ["wes_assay"],
+                            analyzed: ["wes_analysis"]
+                        },
+                        wes_tumor: {
+                            received: ["wes_assay"],
+                            analyzed: ["wes_tumor_only_analysis"]
+                        }
+                    }
+                };
             case "/trial_metadata/summaries":
                 return [
                     {
@@ -32,8 +69,9 @@ it("displays data as expected", async () => {
                         file_size_bytes: 1e3,
                         clinical_participants: 1,
                         total_participants: 2,
-                        expected_assays: ["wes", "h&e", "ihc"],
+                        expected_assays: ["atacseq", "wes", "h&e", "ihc"],
                         "h&e": 11,
+                        atacseq: 3,
                         wes_normal: 5,
                         wes_tumor: 6,
                         wes_analysis: 5,
@@ -46,8 +84,9 @@ it("displays data as expected", async () => {
                         file_size_bytes: 1e6,
                         clinical_participants: 0,
                         total_participants: 3,
-                        expected_assays: ["h&e", "ihc"],
+                        expected_assays: ["atacseq", "h&e", "ihc"],
                         "h&e": 21,
+                        atacseq: 0,
                         wes_normal: 0,
                         wes_tumor: 0,
                         ihc: 22
@@ -75,6 +114,9 @@ it("displays data as expected", async () => {
         innerText(getByTestId("data-tr1-h&e-received"), "11")
     ).toBeInTheDocument();
     expect(
+        innerText(getByTestId("data-tr1-atacseq-received"), "3")
+    ).toBeInTheDocument();
+    expect(
         innerText(getByTestId("data-tr1-wes_tumor-received"), "6")
     ).toBeInTheDocument();
     expect(
@@ -100,6 +142,21 @@ it("displays data as expected", async () => {
     expect(innerText(wesAnalyzed, "5")).toBeInTheDocument();
     const wesTumorOnlyAnalyzed = getByTestId("data-tr1-wes_tumor-analyzed");
     expect(innerText(wesTumorOnlyAnalyzed, "1")).toBeInTheDocument();
+
+    // links to file browser
+    expect(getByTestId("link-tr1-atacseq-received")).toHaveAttribute(
+        "href",
+        "/browse-data?file_view=1&trial_ids=tr1&facets=atacseq_assay&facets=atacseq%20assay"
+    );
+    // wes_tumor and wes_normal assay point to the same place
+    expect(getByTestId("link-tr1-wes_normal-received")).toHaveAttribute(
+        "href",
+        "/browse-data?file_view=1&trial_ids=tr1&facets=wes_assay"
+    );
+    expect(getByTestId("link-tr1-wes_tumor-received")).toHaveAttribute(
+        "href",
+        "/browse-data?file_view=1&trial_ids=tr1&facets=wes_assay"
+    );
 
     // sample exclusions are displayed on hover
     fireEvent.mouseOver(wesAnalyzed.firstElementChild!);

--- a/src/components/data-overview/DataOverviewPage.test.tsx
+++ b/src/components/data-overview/DataOverviewPage.test.tsx
@@ -34,8 +34,10 @@ it("displays data as expected", async () => {
                         total_participants: 2,
                         expected_assays: ["wes", "h&e", "ihc"],
                         "h&e": 11,
-                        wes: 12,
-                        wes_analysis: 11,
+                        wes_normal: 5,
+                        wes_tumor: 6,
+                        wes_analysis: 5,
+                        wes_tumor_only_analysis: 1,
                         ihc: 0,
                         excluded_samples: { wes_analysis: [excluded] }
                     },
@@ -46,7 +48,8 @@ it("displays data as expected", async () => {
                         total_participants: 3,
                         expected_assays: ["h&e", "ihc"],
                         "h&e": 21,
-                        wes: 0,
+                        wes_normal: 0,
+                        wes_tumor: 0,
                         ihc: 22
                     }
                 ];
@@ -64,14 +67,18 @@ it("displays data as expected", async () => {
     expect(queryByText(/tr1/i)).toBeInTheDocument();
     expect(queryByText(/tr2/i)).toBeInTheDocument();
     expect(queryByText(/h&e/i)).toBeInTheDocument();
-    expect(queryByText(/wes/i)).toBeInTheDocument();
+    expect(queryByText(/wes_normal/i)).toBeInTheDocument();
+    expect(queryByText(/wes_tumor/i)).toBeInTheDocument();
     expect(queryByText(/1 kb/i)).toBeInTheDocument();
     expect(queryByText(/1 mb/i)).toBeInTheDocument();
     expect(
         innerText(getByTestId("data-tr1-h&e-received"), "11")
     ).toBeInTheDocument();
     expect(
-        innerText(getByTestId("data-tr1-wes-received"), "12")
+        innerText(getByTestId("data-tr1-wes_tumor-received"), "6")
+    ).toBeInTheDocument();
+    expect(
+        innerText(getByTestId("data-tr1-wes_normal-received"), "5")
     ).toBeInTheDocument();
     expect(
         innerText(getByTestId("data-tr1-ihc-received"), "0")
@@ -83,11 +90,16 @@ it("displays data as expected", async () => {
         innerText(getByTestId("data-tr2-ihc-received"), "22")
     ).toBeInTheDocument();
     expect(
-        innerText(getByTestId("na-tr2-wes-received"), "-")
+        innerText(getByTestId("na-tr2-wes_tumor-received"), "-")
+    ).toBeInTheDocument();
+    expect(
+        innerText(getByTestId("na-tr2-wes_normal-received"), "-")
     ).toBeInTheDocument();
 
-    const wesAnalyzed = getByTestId("data-tr1-wes-analyzed");
-    expect(innerText(wesAnalyzed, "11")).toBeInTheDocument();
+    const wesAnalyzed = getByTestId("data-tr1-wes_normal-analyzed");
+    expect(innerText(wesAnalyzed, "5")).toBeInTheDocument();
+    const wesTumorOnlyAnalyzed = getByTestId("data-tr1-wes_tumor-analyzed");
+    expect(innerText(wesTumorOnlyAnalyzed, "1")).toBeInTheDocument();
 
     // sample exclusions are displayed on hover
     fireEvent.mouseOver(wesAnalyzed.firstElementChild!);

--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -40,8 +40,8 @@ const ASSAYS_WITH_ANALYSIS = [
     "cytof",
     "rna",
     "tcr",
-    "wes",
-    "wes_tumor_only"
+    "wes_normal",
+    "wes_tumor"
 ];
 
 const HeaderCell = withStyles({
@@ -128,8 +128,21 @@ const AssayCell: React.FC<{
                     : "Samples are expected, but none have been received.";
             break;
         case "analyzed":
-            const analysis =
-                assay === "rna" ? "rna_level1_analysis" : `${assay}_analysis`;
+            let analysis: string;
+            switch (assay) {
+                case "wes_tumor":
+                    analysis = "wes_tumor_only_analysis";
+                    break;
+                case "wes_normal":
+                    analysis = "wes_analysis";
+                    break;
+                case "rna":
+                    analysis = "rna_level1_analysis";
+                    break;
+                default:
+                    analysis = `${assay}_analysis`;
+            }
+
             const excluded =
                 (overview.excluded_samples &&
                     overview.excluded_samples[analysis]) ||
@@ -219,7 +232,9 @@ const DataOverviewRow: React.FC<{
                 </TableCell>
                 {assays.map(assay =>
                     overview.expected_assays.includes(
-                        assay !== "wes_tumor_only" ? assay : "wes"
+                        ["wes_normal", "wes_tumor"].includes(assay)
+                            ? "wes"
+                            : assay
                     ) || overview[assay] > 0 ? (
                         <AssayCell
                             key={assay}
@@ -247,7 +262,9 @@ const DataOverviewRow: React.FC<{
                 {assays.map(assay =>
                     ASSAYS_WITH_ANALYSIS.includes(assay) &&
                     overview.expected_assays.includes(
-                        assay !== "wes_tumor_only" ? assay : "wes"
+                        ["wes_normal", "wes_tumor"].includes(assay)
+                            ? "wes"
+                            : assay
                     ) ? (
                         <AssayCell
                             key={assay}

--- a/src/model/file.ts
+++ b/src/model/file.ts
@@ -24,3 +24,12 @@ export interface DataFile {
 }
 
 export type IHCPlotData = Array<Dictionary<string | number>>;
+
+export interface IFacetsForLinks {
+    facets: {
+        [assay: string]: {
+            received: string[];
+            analyzed: string[];
+        };
+    };
+}


### PR DESCRIPTION
## What

- change WES display on `data-overview` to compensate for the changes in counting in the API
- add links from `data-overview` to `browse-data`, with appropriate `trial_ids` and `facets` params

## Why

- [CIDC-1047](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1047) Update dashboard to reflect WES tumor / normal as in BigQuery/Data Studios
- [CIDC-1054](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1054) Link dashboard with file browser

## How

- change `wes` -> `wes_normal` and `wes_tumor_only` -> `wes_tumor`
- get facets from new `/downloable_files/facet_groups_for_links` in the API, which was added for this purpose

## Remarks

No integrative testing with the API itself

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
