### PR TITLE
CIDC-969 CIDC-994 prod deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 13 Jun 2022
+
+- `changed` related files call to use IApiPage to correctly pull files out of response _items
+
 ## 9 Jun 2022
 
 - `added` ctDNA to list of assays with analyses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 9 Jun 2022
+
+- `added` ctDNA to list of assays with analyses
+
 ## 20 May 2022
 
 - `changed` reverted previous "wes" -> "wes_normal" and "wes_tumor_only" -> "wes_tumor"

--- a/src/components/browse-data/files/FileDetailsPage.test.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.test.tsx
@@ -46,7 +46,7 @@ const mockFetch = (
 ) => {
     apiFetch.mockImplementation(async (url: string) => {
         if (url.includes("related_files")) {
-            return rf;
+            return { _items: rf };
         }
         if (url.includes("download_url")) {
             return dlUrl;

--- a/src/components/browse-data/files/FileDetailsPage.tsx
+++ b/src/components/browse-data/files/FileDetailsPage.tsx
@@ -40,7 +40,7 @@ import BatchDownloadDialog from "../shared/BatchDownloadDialog";
 import { Skeleton } from "@material-ui/lab";
 import { useRootStyles } from "../../../rootStyles";
 import useSWR from "swr";
-import { apiFetch } from "../../../api/api";
+import { apiFetch, IApiPage } from "../../../api/api";
 import { useUserContext } from "../../identity/UserProvider";
 
 const getDownloadUrl = (token: string, fileId: number) =>
@@ -249,10 +249,11 @@ const RelatedFiles: React.FC<{ file: DataFile; token: string }> = ({
     const [batchDownloadOpen, setBatchDownloadOpen] = React.useState<boolean>(
         false
     );
-    const { data: relatedFiles } = useSWR<DataFile[]>([
+    const { data } = useSWR<IApiPage<DataFile>>([
         `/downloadable_files/${file.id}/related_files`,
         token
     ]);
+    const relatedFiles = data?._items;
 
     const header = (
         <Grid

--- a/src/components/browse-data/trials/TrialTable.tsx
+++ b/src/components/browse-data/trials/TrialTable.tsx
@@ -140,7 +140,7 @@ const AssayButtonTable: React.FC<{
                     </AssayTableCell>
                     <AssayTableCell align="center">
                         <Typography variant="overline" color="textSecondary">
-                            Analysis Files
+                            Analysis Ready Files
                         </Typography>
                     </AssayTableCell>
                 </TableRow>

--- a/src/components/data-overview/DataOverviewPage.tsx
+++ b/src/components/data-overview/DataOverviewPage.tsx
@@ -38,6 +38,7 @@ const NONASSAY_FIELDS = [
 
 const ASSAYS_WITH_ANALYSIS = [
     "atacseq",
+    "ctdna",
     "cytof",
     "rna",
     "tcr",


### PR DESCRIPTION
Deploys:
- https://github.com/CIMAC-CIDC/cidc-ui/pull/435
- https://github.com/CIMAC-CIDC/cidc-ui/pull/436

## What

- Modify `FileDetailsPage` to fix "Related Files" section
- Change Trial View UI from "Analysis Files" to "Analysis Ready Files"

## Why

- [CIDC-969](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-969) "Related Files" on file details page is broken
  - with related files, none of the related files are displayed and batch downloads don't work
  - with no related files, the "download related files" button isn't greyed out
- [CIDC-994](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-994) Change Trial View UI from "Analysis Files" to "Analysis Ready Files"

## How

- Change `GET` to `/downloadable_files/<id>/related_files` call to use `IApiPage` to correctly pull files out of response `_items`
- Changed hard-coded label text in `TrialTable`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
