### PR TITLE
CIDC-606 add tooltip with file short_description to File Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 ## 16 Jun 2022
 
 - `added` "Data Exploration" tab
+- `added` tooltip to show file short_description in File Browser
 
 
 ## 15 Jun 2022

--- a/src/components/browse-data/files/FileTable.tsx
+++ b/src/components/browse-data/files/FileTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import InfoTooltip from "../../generic/InfoTooltip";
 import { DataFile } from "../../../model/file";
 import { colors } from "../../../rootStyles";
 import PaginatedTable, { ISortConfig } from "../../generic/PaginatedTable";
@@ -247,8 +248,18 @@ const FileTable: React.FC<IFileTableProps & { token: string }> = props => {
                                     <TableCell>{row.trial_id}</TableCell>
                                     <TableCell>{row.file_ext}</TableCell>
                                     <TableCell>
-                                        {formatDataCategory(
-                                            row.data_category || ""
+                                        {row.short_description == null ? (
+                                            formatDataCategory(
+                                                row.data_category || ""
+                                            )
+                                        ) : (
+                                            <InfoTooltip
+                                                text={row.short_description}
+                                            >
+                                                {formatDataCategory(
+                                                    row.data_category || ""
+                                                )}
+                                            </InfoTooltip>
                                         )}
                                     </TableCell>
                                     <TableCell>


### PR DESCRIPTION
## What

Add tooltip to show file `short_description` in the File Browser.

## Why

[CIDC-606](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-606) Display file `short_description`s in the file table

## How

Use existing `InfoTooltip` from `generic` with the `short_description` already on the files returned for the browser.

## Remarks

- as per Jacob's recommended solution
- no testing is done for tooltips in the `browse-data/shared/FilterProvider`, was unable to figure out how to add a test

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
