### PR TITLE
CIDC-1409 deploy: Allow cimac-biofx-user's to see Transfer Data tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 11 July 2022
+
+- `fixed` corrected timezone for file time uploaded
+
+
 ## 29 Jun 2022
 
 - `fixed` loading for manifest upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 22 July 2022
+
+- `fixed` allowed cimac-biofx-user to see transfer data tab
+
 ## 11 July 2022
 
 - `fixed` corrected timezone for file time uploaded
-
 
 ## 29 Jun 2022
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -55,6 +55,7 @@ jest.mock("./components/identity/IdentityProvider", () => {
                     <UserContext.Provider
                         value={{
                             approval_date: "1/1/1",
+                            showAssays: true,
                             showManifests: true,
                             showAnalyses: true
                         }}

--- a/src/components/header/Header.test.tsx
+++ b/src/components/header/Header.test.tsx
@@ -54,7 +54,14 @@ describe("Header", () => {
         checkVisibility(
             queryByText,
             [],
-            ["browse data", "pipelines", "schema", "manifests", "analyses"]
+            [
+                "browse data",
+                "transfer data",
+                "pipelines",
+                "schema",
+                "manifests",
+                "analyses"
+            ]
         );
     };
 
@@ -99,7 +106,7 @@ describe("Header", () => {
         checkVisibility(
             q1,
             ["browse data", "pipelines", "schema", "data overview"],
-            ["manifests", "analyses"]
+            ["transfer data", "manifests", "analyses"]
         );
         cleanup();
 
@@ -110,7 +117,7 @@ describe("Header", () => {
         checkVisibility(
             q2,
             ["browse data", "pipelines", "schema", "data overview"],
-            ["manifests", "analyses"]
+            ["transfer data", "manifests", "analyses"]
         );
         cleanup();
 
@@ -128,7 +135,7 @@ describe("Header", () => {
                 "manifests",
                 "data overview"
             ],
-            ["analyses"]
+            ["transfer data", "analyses"]
         );
         cleanup();
 
@@ -139,7 +146,14 @@ describe("Header", () => {
         });
         checkVisibility(
             q4,
-            ["browse data", "pipelines", "schema", "analyses", "data overview"],
+            [
+                "browse data",
+                "transfer data",
+                "pipelines",
+                "schema",
+                "analyses",
+                "data overview"
+            ],
             ["manifests"]
         );
         cleanup();
@@ -147,6 +161,7 @@ describe("Header", () => {
         // cidc admin
         const { queryByText: q5 } = renderWithUserContext({
             ...user,
+            showAssays: true,
             showAnalyses: true,
             showManifests: true
         });
@@ -154,6 +169,7 @@ describe("Header", () => {
             q5,
             [
                 "browse data",
+                "transfer data",
                 "pipelines",
                 "schema",
                 "analyses",
@@ -162,12 +178,32 @@ describe("Header", () => {
             ],
             []
         );
+        cleanup();
+
+        // cimac biofx user
+        const { queryByText: q6 } = renderWithUserContext({
+            ...user,
+            showAssays: true
+        });
+        checkVisibility(
+            q6,
+            [
+                "browse data",
+                "transfer data",
+                "pipelines",
+                "schema",
+                "data overview"
+            ],
+            ["manifests", "analyses"]
+        );
+        cleanup();
     });
 
     it("navigates on tab click", () => {
         history.push("/");
         const { getByText } = renderWithUserContext({
             ...user,
+            showAssays: true,
             showAnalyses: true,
             showManifests: true
         });
@@ -192,6 +228,7 @@ describe("Header", () => {
     it("doesn't render on certain pathnames", () => {
         const { queryByTestId } = renderWithUserContext({
             ...user,
+            showAssays: true,
             showAnalyses: true,
             showManifests: true
         });

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -266,7 +266,8 @@ const Header: React.FunctionComponent<RouteComponentProps> = props => {
                                             value: "/browse-data"
                                         },
 
-                                        user.showAnalyses && {
+                                        (user.showAssays ||
+                                            user.showAnalyses) && {
                                             label: "transfer data",
                                             value: "/transfer-data"
                                         },

--- a/src/components/identity/UserProvider.test.tsx
+++ b/src/components/identity/UserProvider.test.tsx
@@ -133,6 +133,7 @@ describe("role-based tab display", () => {
             <div data-testid="results">
                 <p>showAnalyses={user.showAnalyses?.toString()}</p>
                 <p>showManifests={user.showManifests?.toString()}</p>
+                <p>showAssays={user.showAssays?.toString()}</p>
             </div>
         );
     };
@@ -140,9 +141,10 @@ describe("role-based tab display", () => {
     const expectedTabs = [
         { role: "cimac-user", tabs: [] },
         { role: "network-viewer", tabs: [] },
-        { role: "cidc-biofx-user", tabs: ["analyses"] },
+        { role: "cimac-biofx-user", tabs: ["transfer data"] },
+        { role: "cidc-biofx-user", tabs: ["transfer data", "analyses"] },
         { role: "nci-biobank-user", tabs: ["manifests"] },
-        { role: "cidc-admin", tabs: ["analyses", "manifests"] }
+        { role: "cidc-admin", tabs: ["transfer data", "analyses", "manifests"] }
     ];
 
     expectedTabs.forEach(({ role, tabs }) => {

--- a/src/components/identity/UserProvider.tsx
+++ b/src/components/identity/UserProvider.tsx
@@ -10,6 +10,7 @@ import useSWR from "swr";
 
 export interface IAccountWithExtraContext extends Account {
     permissions?: Permission[];
+    showAssays?: boolean;
     showAnalyses?: boolean;
     showManifests?: boolean;
     canDownload?: boolean;
@@ -72,6 +73,11 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
             : null
     );
 
+    const showAssays =
+        user?.role &&
+        ["cimac-biofx-user", "cidc-biofx-user", "cidc-admin"].includes(
+            user.role
+        );
     const showManifests =
         user?.role && ["nci-biobank-user", "cidc-admin"].includes(user.role);
     const showAnalyses =
@@ -84,6 +90,7 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
                   ...authData.userInfo.user,
                   ...user,
                   permissions: permissions._items,
+                  showAssays,
                   showManifests,
                   showAnalyses,
                   canDownload

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -3,7 +3,7 @@ import filesize from "filesize";
 import { reduce } from "lodash";
 
 export const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString(LOCALE, DATE_OPTIONS);
+    return new Date(dateStr + "Z").toLocaleDateString(LOCALE, DATE_OPTIONS);
 };
 
 export const formatFileSize = (


### PR DESCRIPTION
Deploys https://github.com/CIMAC-CIDC/cidc-ui/pull/448

## What

Allow cimac-biofx-user's to see Transfer Data tab, and add test to prevent reversion

## Why

Edgar noted that `cimac-biofx-user`s can no longer see the Transfer Data page

## How

Partial reversion of https://github.com/CIMAC-CIDC/cidc-ui/pull/438

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
