### PR TITLE
CIDC-1408 add windows filelist download command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 27 July 2022
+
+- `added` Windows batch download command
+
 ## 22 July 2022
 
 - `fixed` allowed cimac-biofx-user to see transfer data tab

--- a/src/components/browse-data/shared/BatchDownloadDialog.tsx
+++ b/src/components/browse-data/shared/BatchDownloadDialog.tsx
@@ -170,10 +170,15 @@ const BatchDownloadDialog: React.FC<IBatchDownloadDialogProps> = ({
                         <CIDCMarkdown
                             source={[
                                 "Batches larger than 100MB must be downloaded via [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install). " +
-                                    'Download the "filelist.tsv" file for this file batch,' +
-                                    "and run this command in the desired download directory:",
+                                    'Download the "filelist.tsv" file for this file batch, ' +
+                                    "and run the following command in the desired download directory.",
+                                "On Mac/Linux:",
                                 "```bash",
                                 "cat filelist.tsv | xargs -n 2 -P 8 gsutil cp",
+                                "```",
+                                "On Windows:",
+                                "```bash",
+                                'for /F "tokens=1,2" %a in (filelist.tsv) do gsutil cp %a %b',
                                 "```",
                                 "If you haven't logged in with `gcloud` recently, you'll " +
                                     "need to run `gcloud auth login` first.",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7273167/181369423-f965549e-328e-4ef7-8a7d-dfcc2713b281.png)

## What

Add Windows batch download command for using `filelist.csv` to download batches over 100MB.

## Why

Describe what motivated this Pull Request and why this was necessary. Link to the relevant JIRA Issue. Ex. Closes CIDC-1086

## Remarks

Command originally made by Stephen for Jiexin 28 Jun and successfully used by them.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
