### PR TITLE
CIDC-1424 cross-assay perms not include clinical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,19 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
-## 27 July 2022
+## 11 Aug 2022
+
+- `changed` clinical data NOT included in cross-assay permissions
+
+## 27 Jul 2022
 
 - `added` Windows batch download command
 
-## 22 July 2022
+## 22 Jul 2022
 
 - `fixed` allowed cimac-biofx-user to see transfer data tab
 
-## 11 July 2022
+## 11 Jul 2022
 
 - `fixed` corrected timezone for file time uploaded
 

--- a/src/components/profile/AdminUserPermissionsDialog.test.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.test.tsx
@@ -18,7 +18,7 @@ const WES_PERMISSION = {
     id: 123,
     granted_to_user: GRANTEE.id,
     trial_id: "test-1",
-    upload_type: "wes",
+    upload_type: "wes_fastq",
     _etag: "test-etag"
 };
 const PERMISSIONS = [
@@ -33,21 +33,50 @@ const PERMISSIONS = [
 const INFO = {
     supportedTemplates: {
         assays: [
+            "atacseq_fastq",
+            "clinical_data",
+            "ctdna",
             "cytof",
-            "wes",
-            "atac",
-            "rna",
-            "olink",
-            "ihc",
             "elisa",
+            "hande",
+            "ihc",
+            "microbiome",
             "mif",
-            "tcr",
-            "hande"
+            "misc_data",
+            "nanostring",
+            "olink",
+            "rna_fastq",
+            "rna_bam",
+            "tcr_adaptive",
+            "tcr_fastq",
+            "wes_fastq",
+            "wes_bam"
         ],
-        manifests: [],
-        analyses: []
+        manifests: [
+            "h_and_e",
+            "microbiome_dna",
+            "normal_blood_dna",
+            "normal_tissue_dna",
+            "participants_annotations",
+            "pbmc",
+            "plasma",
+            "tissue_slide",
+            "tumor_tissue_dna",
+            "tumor_tissue_rna",
+            "tumor_normal_pairing"
+        ],
+        analyses: [
+            "atacseq_analysis",
+            "ctdna_analysis",
+            "cytof_analysis",
+            "rna_level1_analysis",
+            "tcr_analysis",
+            "wes_analysis",
+            "wes_tumor_only_analysis",
+            "microbiome_analysis"
+        ]
     },
-    extraDataTypes: []
+    extraDataTypes: ["participants info", "samples info"]
 };
 
 const mockFetch = (trials = TRIALS, perms = PERMISSIONS) => {
@@ -118,7 +147,7 @@ it("handles permission revocation", async () => {
     mockFetch();
     const { findByTestId } = doRender();
     // User has permission to view wes for this trial
-    const checkboxId = `checkbox-${TRIAL.trial_id}-wes`;
+    const checkboxId = `checkbox-${TRIAL.trial_id}-wes_fastq`;
 
     // User has this permission, so box should be checked
     const muiCheckbox = await findByTestId(checkboxId);
@@ -156,10 +185,27 @@ it("handles broad trial permissions", async () => {
         true
     );
 
-    // All upload types are checked for TRIAL.trial_id trial
+    // All upload types are checked and disabled for TRIAL.trial_id trial
+    // except clinical_data, which should be unchecked and enabled
     INFO.supportedTemplates.assays.map(assay => {
-        expect(
-            getNativeCheckbox(getByTestId(`checkbox-test-1-${assay}`)).checked
-        ).toBe(true);
+        if (assay !== "clinical_data") {
+            expect(
+                getNativeCheckbox(getByTestId(`checkbox-test-1-${assay}`))
+                    .checked
+            ).toBe(true);
+            expect(
+                getNativeCheckbox(getByTestId(`checkbox-test-1-${assay}`))
+                    .disabled
+            ).toBe(true);
+        } else {
+            expect(
+                getNativeCheckbox(getByTestId(`checkbox-test-1-${assay}`))
+                    .checked
+            ).toBe(false);
+            expect(
+                getNativeCheckbox(getByTestId(`checkbox-test-1-${assay}`))
+                    .disabled
+            ).toBe(false);
+        }
     });
 });

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -88,9 +88,12 @@ const usePermissions = (token: string, grantee: Account) => {
         getGranularPermission: (trialId?: string, uploadType?: string) =>
             permMap[String([trialId, uploadType])],
         getBroadPermission: (trialId?: string, uploadType?: string) =>
-            permMap[String([trialId, uploadType])] ||
-            permMap[String([trialId, undefined])] ||
-            permMap[String([undefined, uploadType])]
+            uploadType !== "clinical_data"
+                ? permMap[String([trialId, uploadType])] ||
+                  permMap[String([trialId, undefined])] ||
+                  permMap[String([undefined, uploadType])]
+                : permMap[String([trialId, uploadType])] ||
+                  permMap[String([undefined, uploadType])]
     };
 };
 
@@ -154,6 +157,31 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                 <TableCell className={classes.trialCell}>
                                     Trial
                                 </TableCell>
+                                <TableCell
+                                    key={"clinical_data"}
+                                    size="small"
+                                    align="center"
+                                >
+                                    <Grid
+                                        container
+                                        direction="row"
+                                        alignItems="center"
+                                    >
+                                        <Grid item>Clinical</Grid>
+                                        <Grid item>
+                                            <PermCheckbox
+                                                grantee={props.grantee}
+                                                granter={props.granter}
+                                                uploadType={"clinical_data"}
+                                                token={props.token}
+                                                disableIfUnchecked={
+                                                    tooManyPerms
+                                                }
+                                            />
+                                        </Grid>
+                                    </Grid>
+                                </TableCell>
+
                                 {props.supportedTypes.map(uploadType => (
                                     <TableCell
                                         key={uploadType}
@@ -206,24 +234,39 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                             </Grid>
                                         </Grid>
                                     </TableCell>
+                                    <TableCell
+                                        key={"clinical_data" + trial.trial_id}
+                                        align="center"
+                                    >
+                                        <PermCheckbox
+                                            grantee={props.grantee}
+                                            granter={props.granter}
+                                            trialId={trial.trial_id}
+                                            uploadType={"clinical_data"}
+                                            token={props.token}
+                                            disableIfUnchecked={tooManyPerms}
+                                        />
+                                    </TableCell>
                                     {props.supportedTypes.map(typ => {
-                                        return (
-                                            <TableCell
-                                                key={typ + trial.trial_id}
-                                                align="center"
-                                            >
-                                                <PermCheckbox
-                                                    grantee={props.grantee}
-                                                    granter={props.granter}
-                                                    trialId={trial.trial_id}
-                                                    uploadType={typ}
-                                                    token={props.token}
-                                                    disableIfUnchecked={
-                                                        tooManyPerms
-                                                    }
-                                                />
-                                            </TableCell>
-                                        );
+                                        if (typ !== "clinical_data") {
+                                            return (
+                                                <TableCell
+                                                    key={typ + trial.trial_id}
+                                                    align="center"
+                                                >
+                                                    <PermCheckbox
+                                                        grantee={props.grantee}
+                                                        granter={props.granter}
+                                                        trialId={trial.trial_id}
+                                                        uploadType={typ}
+                                                        token={props.token}
+                                                        disableIfUnchecked={
+                                                            tooManyPerms
+                                                        }
+                                                    />
+                                                </TableCell>
+                                            );
+                                        }
                                     })}
                                 </TableRow>
                             ))}

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -266,6 +266,8 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                                     />
                                                 </TableCell>
                                             );
+                                        } else {
+                                            return;
                                         }
                                     })}
                                 </TableRow>

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -46,6 +46,11 @@ const UserPermissionsDialogWithInfo: React.FC<IUserPermissionsDialogProps> = pro
         ...supportedTemplates.analyses,
         ...extraDataTypes
     ];
+    const index = supportedTypes.indexOf("clinical_data");
+    if (index > -1) {
+        // only splice array when item is found
+        supportedTypes.splice(index, 1); // 2nd parameter means remove one item only
+    }
 
     return (
         <UserPermissionsDialog
@@ -248,27 +253,23 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                         />
                                     </TableCell>
                                     {props.supportedTypes.map(typ => {
-                                        if (typ !== "clinical_data") {
-                                            return (
-                                                <TableCell
-                                                    key={typ + trial.trial_id}
-                                                    align="center"
-                                                >
-                                                    <PermCheckbox
-                                                        grantee={props.grantee}
-                                                        granter={props.granter}
-                                                        trialId={trial.trial_id}
-                                                        uploadType={typ}
-                                                        token={props.token}
-                                                        disableIfUnchecked={
-                                                            tooManyPerms
-                                                        }
-                                                    />
-                                                </TableCell>
-                                            );
-                                        } else {
-                                            return;
-                                        }
+                                        return (
+                                            <TableCell
+                                                key={typ + trial.trial_id}
+                                                align="center"
+                                            >
+                                                <PermCheckbox
+                                                    grantee={props.grantee}
+                                                    granter={props.granter}
+                                                    trialId={trial.trial_id}
+                                                    uploadType={typ}
+                                                    token={props.token}
+                                                    disableIfUnchecked={
+                                                        tooManyPerms
+                                                    }
+                                                />
+                                            </TableCell>
+                                        );
                                     })}
                                 </TableRow>
                             ))}


### PR DESCRIPTION
Parallels:
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/543
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/722
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/374

## What

- In admin permissions display table, change cross-assay single-trial permission to NOT include the clinical data
- Add back a separate clinical data checkbox set

## Why

- [CIDC-1424](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1424) Make changes to portal access provider to simplify enabling clinical data access

## How

- don't use cross-assay perm to control `clinical_data` checkbox
- add new column for `clinical_data` checkmark
- don't generate `clinical_data` checkboxes from mapping

## Remarks

- updated test mocks of info endpoints to correctly use the `upload_type` instead of a broader name
- added test to make sure that `clinical_data` is unchecked and enabled despite having cross-assay permission

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
