### PR TITLE
CIDC-1278 don't replace assays with metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 14 Sep 2022
+
+- `changed` template download button to point to /templates/assays not /templates/metadata
+
 ## 11 Aug 2022
 
 - `changed` clinical data NOT included in cross-assay permissions

--- a/src/components/generic/TemplateDownloadButton.tsx
+++ b/src/components/generic/TemplateDownloadButton.tsx
@@ -9,9 +9,7 @@ export function nameToURL(
     name: string
 ) {
     const fmtedName = name.toLowerCase().replace(" ", "_");
-    // Assay templates have type "metadata" on the server
-    const fixedType = type === "assays" ? "metadata" : type;
-    return `${process.env.REACT_APP_API_URL}/info/templates/${fixedType}/${fmtedName}`;
+    return `${process.env.REACT_APP_API_URL}/info/templates/${type}/${fmtedName}`;
 }
 
 export interface ITemplateDownloadButtonProps extends ButtonProps {


### PR DESCRIPTION
Parallels
- https://github.com/CIMAC-CIDC/cidc-schemas/pull/549
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/729

## What

Schemas bump for docs update / DM clean-up
moved `schemas/templates/metadata` to `schemas/templates/assays`

## Why

[CIDC-1278](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1278) Update portal schema docs

## How

Remove ternary conditional to replace

## Remarks

This page has no tests

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
