### PR TITLE
CIDC-1484 Prod deploy: add pact user role

### DIFF
--- a/src/components/identity/UserProvider.test.tsx
+++ b/src/components/identity/UserProvider.test.tsx
@@ -112,7 +112,7 @@ describe("download access", () => {
 
             expect(
                 await findByText(
-                    role === "network-viewer"
+                    ["network-viewer", "pact-user"].includes(role)
                         ? /cannot download/i
                         : /can download/i
                 )
@@ -140,6 +140,7 @@ describe("role-based tab display", () => {
 
     const expectedTabs = [
         { role: "cimac-user", tabs: [] },
+        { role: "pact-user", tabs: [] },
         { role: "network-viewer", tabs: [] },
         { role: "cimac-biofx-user", tabs: ["transfer data"] },
         { role: "cidc-biofx-user", tabs: ["transfer data", "analyses"] },

--- a/src/components/identity/UserProvider.tsx
+++ b/src/components/identity/UserProvider.tsx
@@ -82,7 +82,8 @@ const UserProvider: React.FunctionComponent<RouteComponentProps> = props => {
         user?.role && ["nci-biobank-user", "cidc-admin"].includes(user.role);
     const showAnalyses =
         user?.role && ["cidc-biofx-user", "cidc-admin"].includes(user.role);
-    const canDownload = user?.role !== "network-viewer";
+    const canDownload =
+        user?.role && !["network-viewer", "pact-user"].includes(user.role);
 
     const value =
         authData.state === "logged-in" && user && permissions

--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -8,7 +8,8 @@ type Role =
     | "devops"
     | "nci-biobank-user"
     | "system"
-    | "network-viewer";
+    | "network-viewer"
+    | "pact-user";
 
 type Organization = "CIDC" | "DFCI" | "ICAHN" | "STANFORD" | "ANDERSON";
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -14,7 +14,8 @@ export const ROLES = [
     "developer",
     "devops",
     "nci-biobank-user",
-    "network-viewer"
+    "network-viewer",
+    "pact-user"
 ];
 
 export const DATE_OPTIONS = {


### PR DESCRIPTION
Deploys:
- https://github.com/CIMAC-CIDC/cidc-ui/commit/1132cfbace1161e8eeaa17f20224bb271fa518e8

Parallels:
- https://github.com/CIMAC-CIDC/cidc-cloud-functions/pull/387
- https://github.com/CIMAC-CIDC/cidc-api-gae/pull/734

## What

Add a role for PACT users that is equivalent to the Network viewer role.

## Why

- [CIDC-1484](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1484) Add PACT User Type

## How

Added to enums, changed all `!== network-viewer` to `![network-viewer, pact-user].includes`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
