### PR TITLE
CIDC-1485 open Data Exploration links to in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This Changelog tracks changes to this project. The notes below include a summary
 
 - `changed` Data Exploration > Code-based View, update for new templates and permissions scheme
 - `fixed` bug in pipelines docs pointing to chips instead of atacseq
+- `changed` Data Exploration links to open in new tab
 
 ## 14 Sep 2022
 

--- a/src/components/data-exploration/code-based/CodeBasedExploration.tsx
+++ b/src/components/data-exploration/code-based/CodeBasedExploration.tsx
@@ -128,14 +128,22 @@ const CodeBasedExplorationPage: React.FC<{
                                     )
                                 ) : item.description == null ? (
                                     <li key={item.name}>
-                                        <a href={item.destination}>
+                                        <a
+                                            href={item.destination}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
                                             {item.name}
                                         </a>
                                     </li>
                                 ) : (
                                     <li key={item.name}>
                                         <b>
-                                            <a href={item.destination}>
+                                            <a
+                                                href={item.destination}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                            >
                                                 {item.name}
                                             </a>
                                         </b>{" "}

--- a/src/components/data-exploration/interactive/InteractiveExploration.tsx
+++ b/src/components/data-exploration/interactive/InteractiveExploration.tsx
@@ -132,7 +132,11 @@ const InteractiveExplorationPage: React.FC<{
                                     }
                                 ].map(item => (
                                     <li>
-                                        <a href={item.destination}>
+                                        <a
+                                            href={item.destination}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
                                             {item.name}
                                         </a>
                                     </li>


### PR DESCRIPTION
## What

Open Data Exploration links to in new tab

## Why

- [CIDC-1485](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1485) suggested by Joyce

## How

- add `target="_blank" rel="noopener noreferrer"` to all links on data exploration

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
