### PR TITLE
CIDC-1501 add "not applicable" organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 25 Oct 2022
+
+- `added` N/A organization for users
+
 ## 17 Oct 2022
 
 - `changed` Data Exploration > Code-based View, update for new templates and permissions scheme

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -3,7 +3,8 @@ export const ORGANIZATION_NAME_MAP = {
     CIDC: "Dana-Farber Cancer Institute (CIDC)",
     ICAHN: "Icahn School of Medicine at Mount Sinai (CIMAC)",
     STANFORD: "Stanford Cancer Institute (CIMAC)",
-    ANDERSON: "MD Anderson Cancer Center (CIMAC)"
+    ANDERSON: "MD Anderson Cancer Center (CIMAC)",
+    "N/A": "Not Applicable"
 };
 
 export const ROLES = [


### PR DESCRIPTION
## What

Add "N/A": "Not Applicable" organization to users table for registration of PACT users.

## Why

[CIDC-1501](https://dfcijira.dfci.harvard.edu:8443/browse/CIDC-1501) Add not applicable to Institution for User registration page.

## How

Added to organizations mapping in `src/utils/constants.ts`

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
