### PR TITLE
CIDC-1565 pin setup-gcloud version to stable version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           name: build-artifacts
           path: build
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ github.ref == 'refs/heads/production'  && 'cidc-dfci' || 'cidc-dfci-staging' }}
           service_account_key: ${{ github.ref == 'refs/heads/production'  && secrets.GCP_SA_KEY_PROD || secrets.GCP_SA_KEY_STAGING }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 02 Dec 2022
+
+- `changed` updated google-github-actions/setup-gcloud version to be pinned to v0
+
 ## 01 Dec 2022
 
 - `changed` updated looker studio link to cimac account owned version


### PR DESCRIPTION
## What

pinned google-github-actions/setup-gcloud version to v0

## Why

still using deprecated deployment element that is useable in v0 and not in main

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [ ] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
