### PR TITLE
CIDC-1632 fix file type facetting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 09 Feb 2023
+
+- `fixed` facet bug with files types that contain symbols
+
 ## 26 Jan 2023
 
 - `removed` stale GitHub action for automatic prod releases

--- a/src/components/browse-data/shared/FilterCheckboxGroup.tsx
+++ b/src/components/browse-data/shared/FilterCheckboxGroup.tsx
@@ -23,6 +23,7 @@ import InfoTooltip from "../../generic/InfoTooltip";
 import { IFacetInfo } from "./FilterProvider";
 import { Skeleton } from "@material-ui/lab";
 import { theme } from "../../../rootStyles";
+import { formatFacetType } from "../../../util/utils";
 
 const searchBoxMargin = 15;
 
@@ -166,7 +167,9 @@ const PermsAwareCheckbox: React.FC<IPermsAwareCheckboxProps> = ({
             permissions || [],
             p =>
                 p.trial_id === facetType ||
-                p.upload_type?.startsWith(facetType.toLowerCase()) ||
+                p.upload_type?.startsWith(
+                    formatFacetType(facetType.toLowerCase())
+                ) ||
                 // cross-trial permission
                 p.trial_id === null ||
                 // cross-assay permission

--- a/src/util/utils.test.ts
+++ b/src/util/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatDataCategory, naivePluralize } from "./utils";
+import { formatDataCategory, naivePluralize, formatFacetType } from "./utils";
 
 test("formatDataCategory", () => {
     expect(formatDataCategory("Foo|Bar")).toBe("Foo Bar");
@@ -13,4 +13,12 @@ test("naivePluralize", () => {
     expect(naivePluralize(word, 0)).toBe(words);
     expect(naivePluralize(word, 1)).toBe(word);
     expect(naivePluralize(word, 2)).toBe(words);
+});
+
+test("formatFacetType", () => {
+    expect(formatFacetType("H&E".toLowerCase())).toBe("hande");
+    expect(formatFacetType("ATAC-Seq".toLowerCase())).toBe("atacseq");
+    expect(formatFacetType("WES Tumor-Only".toLowerCase())).toBe(
+        "wes_tumor_only"
+    );
 });

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -32,7 +32,7 @@ export const formatQueryString = (
 
 export const formatFacetType = (facetType: string) => {
     return facetType
-        .replaceAll("&", "and")
+        .replace("&", "and")
         .replace("atac-seq", "atacseq")
         .replace("wes tumor-only", "wes_tumor_only");
 };

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -32,7 +32,7 @@ export const formatQueryString = (
 
 export const formatFacetType = (facetType: string) => {
     return facetType
-        .replace("&", "and")
+        .replaceAll("&", "and")
         .replace("atac-seq", "atacseq")
         .replace("wes tumor-only", "wes_tumor_only");
 };

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -32,7 +32,7 @@ export const formatQueryString = (
 
 export const formatFacetType = (facetType: string) => {
     return facetType
-        .replace("&", "and")
+        .replace("h&e", "hande")
         .replace("atac-seq", "atacseq")
         .replace("wes tumor-only", "wes_tumor_only");
 };

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -30,6 +30,13 @@ export const formatQueryString = (
     );
 };
 
+export const formatFacetType = (facetType: string) => {
+    return facetType
+        .replace("&", "and")
+        .replace("atac-seq", "atacseq")
+        .replace("wes tumor-only", "wes_tumor_only");
+};
+
 export const naivePluralize = (str: string, n: number) => {
     return n !== 1 ? str + "s" : str;
 };


### PR DESCRIPTION
## What

fix facets for users with access to H&E, wes tumor_only, and atacseq 

## Why

when given access to to a single one of the above file types, users are unable to select the file view facets for those file types

## How

convert the facet names into the upload types


## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [ ] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [x] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
