### PR TITLE
Remove max perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## 24 May 2023
+
+- `removed` MAX_PERMS restriction
+
 ## 06 Mar 2023
 
 - `fixed` old looker studio links in data exploration

--- a/src/components/profile/AdminUserPermissionsDialog.test.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.test.tsx
@@ -79,6 +79,114 @@ const INFO = {
     extraDataTypes: ["participants info", "samples info"]
 };
 
+const MORE_THAN_20_PERMS = [
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "tcr_fastq"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "rna_fastq"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "clinical_data"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "olink"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "ctdna"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "atacseq_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "misc_data"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "wes_bam"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "rna_bam"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "microbiome"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "tcr_adaptive"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "wes_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "rna_level1_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "ihc"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "wes_fastq"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "elisa"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "microbiome_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "cytof_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "mif"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "ctdna_analysis"
+    },
+    {
+        granted_to_user: GRANTEE.id,
+        trial_id: "trial_1",
+        upload_type: "tcr_analysis"
+    }
+];
+
 const mockFetch = (trials = TRIALS, perms = PERMISSIONS) => {
     apiFetch.mockImplementation(async (url: string) => {
         if (url.includes("/trial_metadata")) {
@@ -104,142 +212,6 @@ function doRender() {
         </InfoContext.Provider>
     );
 }
-
-it("can handle more than 20 permissions", async () => {
-    const perms = [
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "tcr_fastq"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "rna_fastq"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "clinical_data"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "olink"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "ctdna"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "atacseq_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "misc_data"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "wes_bam"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "rna_bam"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "microbiome"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "tcr_adaptive"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "wes_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "rna_level1_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "ihc"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "wes_fastq"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "elisa"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "microbiome_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "cytof_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "mif"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "ctdna_analysis"
-        },
-        {
-            granted_to_user: GRANTEE.id,
-            trial_id: "trial-1",
-            upload_type: "tcr_analysis"
-        }
-    ];
-    expect(perms.length).toBeGreaterThan(20);
-    mockFetch([
-        {
-            trial_id: "trial-1"
-        }
-    ] as Trial[]);
-    const { findByTestId } = doRender();
-
-    for (const perm of perms) {
-        const checkbox = await findByTestId(
-            `checkbox-trial-1-${perm.upload_type}`
-        );
-        const nativeCheckbox = getNativeCheckbox(checkbox);
-        expect(nativeCheckbox.checked).toBe(false);
-        fireEvent.click(nativeCheckbox);
-        await waitFor(() => {
-            expect(apiCreate).toHaveBeenCalledWith("/permissions", TOKEN, {
-                data: {
-                    granted_to_user: GRANTEE.id,
-                    granted_by_user: GRANTER.id,
-                    trial_id: "trial-1",
-                    upload_type: perm.upload_type
-                }
-            });
-        });
-    }
-});
 
 it("renders existing permissions", async () => {
     mockFetch();
@@ -344,4 +316,29 @@ it("handles broad trial permissions", async () => {
             ).toBe(false);
         }
     });
+});
+
+it("can handle more than 20 permissions", async () => {
+    expect(MORE_THAN_20_PERMS.length).toBeGreaterThan(20);
+    mockFetch([{ trial_id: "trial_1" }] as Trial[]);
+    const { findByTestId } = doRender();
+
+    for (const perm of MORE_THAN_20_PERMS) {
+        const checkbox = await findByTestId(
+            `checkbox-trial_1-${perm.upload_type}`
+        );
+        const nativeCheckbox = getNativeCheckbox(checkbox);
+        expect(nativeCheckbox.checked).toBe(false);
+        fireEvent.click(nativeCheckbox);
+        await waitFor(() => {
+            expect(apiCreate).toHaveBeenCalledWith("/permissions", TOKEN, {
+                data: {
+                    granted_to_user: GRANTEE.id,
+                    granted_by_user: GRANTER.id,
+                    trial_id: "trial_1",
+                    upload_type: perm.upload_type
+                }
+            });
+        });
+    }
 });

--- a/src/components/profile/AdminUserPermissionsDialog.test.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.test.tsx
@@ -341,4 +341,4 @@ it("can handle more than 20 permissions", async () => {
             });
         });
     }
-});
+}, 30_000);

--- a/src/components/profile/AdminUserPermissionsDialog.test.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.test.tsx
@@ -105,6 +105,142 @@ function doRender() {
     );
 }
 
+it("can handle more than 20 permissions", async () => {
+    const perms = [
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "tcr_fastq"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "rna_fastq"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "clinical_data"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "olink"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "ctdna"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "atacseq_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "misc_data"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "wes_bam"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "rna_bam"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "microbiome"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "tcr_adaptive"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "wes_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "rna_level1_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "ihc"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "wes_fastq"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "elisa"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "microbiome_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "cytof_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "mif"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "ctdna_analysis"
+        },
+        {
+            granted_to_user: GRANTEE.id,
+            trial_id: "trial-1",
+            upload_type: "tcr_analysis"
+        }
+    ];
+    expect(perms.length).toBeGreaterThan(20);
+    mockFetch([
+        {
+            trial_id: "trial-1"
+        }
+    ] as Trial[]);
+    const { findByTestId } = doRender();
+
+    for (const perm of perms) {
+        const checkbox = await findByTestId(
+            `checkbox-trial-1-${perm.upload_type}`
+        );
+        const nativeCheckbox = getNativeCheckbox(checkbox);
+        expect(nativeCheckbox.checked).toBe(false);
+        fireEvent.click(nativeCheckbox);
+        await waitFor(() => {
+            expect(apiCreate).toHaveBeenCalledWith("/permissions", TOKEN, {
+                data: {
+                    granted_to_user: GRANTEE.id,
+                    granted_by_user: GRANTER.id,
+                    trial_id: "trial-1",
+                    upload_type: perm.upload_type
+                }
+            });
+        });
+    }
+});
+
 it("renders existing permissions", async () => {
     mockFetch();
     const { findByTestId } = doRender();

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -20,7 +20,6 @@ import { InfoContext } from "../info/InfoProvider";
 import Loader from "../generic/Loader";
 import { UserContext } from "../identity/UserProvider";
 import useSWR from "swr";
-import { Alert } from "@material-ui/lab";
 import { groupBy, mapValues } from "lodash";
 
 export interface IUserPermissionsDialogProps {
@@ -262,8 +261,7 @@ const PermCheckbox: React.FunctionComponent<{
     token: string;
     trialId?: string;
     uploadType?: string;
-    disableIfUnchecked?: boolean;
-}> = ({ grantee, granter, token, trialId, uploadType, disableIfUnchecked }) => {
+}> = ({ grantee, granter, token, trialId, uploadType }) => {
     const {
         data,
         mutate,

--- a/src/components/profile/AdminUserPermissionsDialog.tsx
+++ b/src/components/profile/AdminUserPermissionsDialog.tsx
@@ -102,19 +102,16 @@ const usePermissions = (token: string, grantee: Account) => {
     };
 };
 
-const MAX_PERMS = 20;
-
 const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
     supportedTypes: string[];
     granter: Account;
 }> = props => {
     const classes = useStyles();
 
-    const { data: permBundle, isValidating: loadingPerms } = usePermissions(
+    const { isValidating: loadingPerms } = usePermissions(
         props.token,
         props.grantee
     );
-    const tooManyPerms = (permBundle?._items || []).length >= MAX_PERMS;
 
     const { data: trialBundle } = useSWR<IApiPage<Trial>>(
         props.open ? ["/trial_metadata?page_size=200", props.token] : null
@@ -142,17 +139,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                     </Grid>
                     <Grid item>{loadingPerms && <Loader size={25} />}</Grid>
                 </Grid>
-                {tooManyPerms && (
-                    <Alert severity="warning">
-                        <strong>
-                            Please remove a permission if you need to add
-                            another.
-                        </strong>{" "}
-                        Due to Google Cloud Storage IAM limitations, a user can
-                        have a maximum of {MAX_PERMS} separate permissions
-                        granted to them.
-                    </Alert>
-                )}
             </DialogTitle>
             <DialogContent>
                 {trials ? (
@@ -179,9 +165,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                                 granter={props.granter}
                                                 uploadType={"clinical_data"}
                                                 token={props.token}
-                                                disableIfUnchecked={
-                                                    tooManyPerms
-                                                }
                                             />
                                         </Grid>
                                     </Grid>
@@ -205,9 +188,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                                     granter={props.granter}
                                                     uploadType={uploadType}
                                                     token={props.token}
-                                                    disableIfUnchecked={
-                                                        tooManyPerms
-                                                    }
                                                 />
                                             </Grid>
                                         </Grid>
@@ -232,9 +212,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                                     granter={props.granter}
                                                     trialId={trial.trial_id}
                                                     token={props.token}
-                                                    disableIfUnchecked={
-                                                        tooManyPerms
-                                                    }
                                                 />
                                             </Grid>
                                         </Grid>
@@ -249,7 +226,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                             trialId={trial.trial_id}
                                             uploadType={"clinical_data"}
                                             token={props.token}
-                                            disableIfUnchecked={tooManyPerms}
                                         />
                                     </TableCell>
                                     {props.supportedTypes.map(typ => {
@@ -264,9 +240,6 @@ const UserPermissionsDialog: React.FC<IUserPermissionsDialogProps & {
                                                     trialId={trial.trial_id}
                                                     uploadType={typ}
                                                     token={props.token}
-                                                    disableIfUnchecked={
-                                                        tooManyPerms
-                                                    }
                                                 />
                                             </TableCell>
                                         );
@@ -289,7 +262,7 @@ const PermCheckbox: React.FunctionComponent<{
     token: string;
     trialId?: string;
     uploadType?: string;
-    disableIfUnchecked: boolean;
+    disableIfUnchecked?: boolean;
 }> = ({ grantee, granter, token, trialId, uploadType, disableIfUnchecked }) => {
     const {
         data,
@@ -332,11 +305,7 @@ const PermCheckbox: React.FunctionComponent<{
     return (
         <Checkbox
             data-testid={`checkbox-${trialId}-${uploadType}`}
-            disabled={
-                isValidating ||
-                (!perm && disableIfUnchecked) ||
-                (!granularPerm && !!broadPerm)
-            }
+            disabled={isValidating || (!granularPerm && !!broadPerm)}
             onChange={handleChange}
             checked={!!perm}
         />


### PR DESCRIPTION
## What

- `removed` MAX_PERMS restriction allowing Admins to give more than 20 separate permissions per user

## Why

From @scvannost ,
> We used to use IAM for data perms with prefix conditions to limit their scope, and there's a limit (as in the message) of 20 different permissions for a user on a bucket; it also relied on using undocumented wildcards for single-assay cross-trial permissions.
When the wildcards stopped working (likely removed by Google), this was remedied by switching to ACL-based permissions for each file individually so no such limit applies.

## How

Removed the MAX_PERMS constant and all dependent references.
Tested by,
- running locally (but with connection to Cloud Storage)
- as cidc-admin role, assign 20+ separate permissions to a biofx user
- verify permissions in db
- verify permissions in GCS on each object

## Remarks

Checked the API/Cloud Functions for any references to permissions limit. API mentions `GOOGLE_MAX_DOWNLOAD_PERMISSIONS = 20`, but the function it's used in is not being referenced anywhere.

## Checklist

Please include and complete the following checklist. You can mark an item as complete with the `- [x]` prefix:

- [x] Tests - Added unit tests for new code, regression tests for bugs and updated the integration tests if required
- [ ] Formatting & Linting - `tslint` has been used to ensure styling guidelines are met
- [ ] Docstrings - Docstrings have been provided for functions
- [x] Documentation - [README](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/README.md) and [CHANGELOG](https://github.com/CIMAC-CIDC/cidc-ui/blob/master/CHANGELOG.md) have been updated to explain major changes & new features
